### PR TITLE
chore(security): harden CI/CD pipelines with SHA-pinned GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/init@b14c7811d99f9972fdf29f4247b2cde20f3df329 # v4.35.0
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -98,6 +98,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/analyze@b14c7811d99f9972fdf29f4247b2cde20f3df329 # v4.35.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -69,7 +69,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -98,6 +98,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       url: https://pypi.org/p/qwed-tax
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.10"
 
@@ -44,10 +44,10 @@ jobs:
       url: https://www.npmjs.com/package/@qwed-ai/tax
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Snyk CLI
-        run: npm install -g snyk@1.1303.1
+        run: npm install -g snyk@1.1303.2
 
       - name: Install Python dependencies
         run: |
@@ -45,7 +45,7 @@ jobs:
         run: snyk test --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
 
       - name: Upload Snyk Python results to GitHub Security
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/upload-sarif@b14c7811d99f9972fdf29f4247b2cde20f3df329 # v4.35.0
         if: always() && hashFiles('snyk-python.sarif') != ''
         with:
           sarif_file: snyk-python.sarif
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Install Snyk CLI
-        run: npm install -g snyk@1.1303.1
+        run: npm install -g snyk@1.1303.2
 
       - name: Snyk Code analysis
         env:
@@ -68,7 +68,7 @@ jobs:
         run: snyk code test --org=${{ secrets.SNYK_ORG_ID }} --sarif-file-output=snyk-code.sarif
 
       - name: Upload Snyk Code results
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/upload-sarif@b14c7811d99f9972fdf29f4247b2cde20f3df329 # v4.35.0
         if: always() && hashFiles('snyk-code.sarif') != ''
         with:
           sarif_file: snyk-code.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -21,10 +21,10 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.11'
 
@@ -45,7 +45,7 @@ jobs:
         run: snyk test --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
 
       - name: Upload Snyk Python results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         if: always() && hashFiles('snyk-python.sarif') != ''
         with:
           sarif_file: snyk-python.sarif
@@ -57,7 +57,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Install Snyk CLI
         run: npm install -g snyk@1.1303.1
@@ -68,7 +68,7 @@ jobs:
         run: snyk code test --org=${{ secrets.SNYK_ORG_ID }} --sarif-file-output=snyk-code.sarif
 
       - name: Upload Snyk Code results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         if: always() && hashFiles('snyk-code.sarif') != ''
         with:
           sarif_file: snyk-code.sarif

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,12 +17,12 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0  # Full history for better analysis relevancy
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.11'
 
@@ -37,7 +37,7 @@ jobs:
           pytest --cov=qwed_tax --cov-report=xml --cov-report=term-missing tests/
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@689fb39b34b9aa95ebc5f8f119343ddd51542402 # v4
+        uses: SonarSource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.11'
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: QWED-AI/qwed-tax


### PR DESCRIPTION
## Security Hardening: GitHub Actions SHA Pinning

### 🔒 Description
This PR significantly hardens the repository's supply-chain security by pinning all third-party GitHub Actions to specific cryptographic SHA-1 commit hashes instead of mutable version tags (e.g., `@v4`).

Mutable tags create a potential supply chain vulnerability. If a malicious actor gains access to a third-party action's repository and re-tags a malicious commit, CI pipelines using the vague tag will automatically pull and execute untrusted code. SHA-pinning eliminates this risk, guaranteeing deterministic execution.

### 🛠️ Key Changes
- Pinned `actions/checkout@v4` to official SHA `692973... # v4.1.7`.
- Pinned `actions/setup-python@v5` to official SHA `82c7e6... # v5.1.0`.
- Transitioned deprecated `sonarcloud-github-action` to officially supported `SonarSource/sonarqube-scan-action` and pinned it to `bfd4e5... # v4.2.1`.
- Pinned other CI utilities (like `codecov-action` and `codeql`) to their respective verified SHAs.
- Retained human-readable version tags as comments (`# vX.Y.Z`) for maintainability and update-tracking.

### ✅ Verification
- Analyzed and updated existing workflow files via `npx pin-github-action` and custom CI scripts.
- Verified that all SHAs match their corresponding official release references.
- No functional application code was altered; changes strictly apply to CI configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to pin GitHub Actions to specific commit SHAs instead of floating version tags for more reproducible and secure runs.
  * Snyk CLI version incremented in security scan workflow.
  * No functional build, test, publish, or runtime behavior was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->