### PR TITLE
fix: fail closed tax preflight intent routing

### DIFF
--- a/examples/verify_tax_expansion.py
+++ b/examples/verify_tax_expansion.py
@@ -44,6 +44,7 @@ def test_nexus_guard():
     
     # Test 3: Nexus Violation (NY > $500k)
     intent_nexus = {
+        "action": "economic_nexus",
         "state": "NY",
         "sales_data": {"amount": 500001, "transactions": 10},
         "tax_decision": "no_tax" # Hallucination
@@ -56,6 +57,7 @@ def test_nexus_guard():
 
     # Test 4: Safe State (Below Threshold)
     intent_safe = {
+        "action": "economic_nexus",
         "state": "FL",
         "sales_data": {"amount": 50000, "transactions": 10},
         "tax_decision": "no_tax"

--- a/qwed_tax/guards/remittance_guard.py
+++ b/qwed_tax/guards/remittance_guard.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Dict, Any, List
 
 class RemittanceGuard:
@@ -13,8 +13,14 @@ class RemittanceGuard:
         Source: Audit Trace 3253e38e9d60
         """
         limit = Decimal("250000") # $250k annual limit
-        current_txn = Decimal(str(amount_usd))
-        usage = Decimal(str(financial_year_usage))
+        try:
+            current_txn = Decimal(str(amount_usd))
+            usage = Decimal(str(financial_year_usage))
+        except InvalidOperation:
+            return {
+                "verified": False,
+                "error": "BLOCKED: Remittance verification requires numeric amount_usd and financial_year_usage values."
+            }
         
         # 1. Prohibited Transactions Check (Schedule I)
         prohibited_purposes = ["GAMBLING", "LOTTERY", "RACING", "BANNED_MAGAZINES", "SWEEPSTAKES", "MARGIN_TRADING"]
@@ -38,7 +44,10 @@ class RemittanceGuard:
         Deterministically calculates Tax Collected at Source (TCS).
         Rule: Education (Loan) = 0.5%, Education (Self) = 5%, Other = 20%
         """
-        amt = Decimal(str(amount_inr))
+        try:
+            amt = Decimal(str(amount_inr))
+        except InvalidOperation as exc:
+            raise ValueError("amount_inr must be numeric for TCS calculation.") from exc
         threshold = Decimal("700000") # 7 Lakhs exemption
         
         if amt <= threshold:

--- a/qwed_tax/guards/remittance_guard.py
+++ b/qwed_tax/guards/remittance_guard.py
@@ -10,6 +10,7 @@ class RemittanceGuard:
     def verify_lrs_limit(self, amount_usd: float, purpose: str, financial_year_usage: float) -> Dict[str, Any]:
         """
         Verifies Liberalised Remittance Scheme (LRS) limits.
+        Returns a verification report dict and fails closed on invalid numeric inputs.
         Source: Audit Trace 3253e38e9d60
         """
         limit = Decimal("250000") # $250k annual limit
@@ -20,6 +21,11 @@ class RemittanceGuard:
             return {
                 "verified": False,
                 "error": "BLOCKED: Remittance verification requires numeric amount_usd and financial_year_usage values."
+            }
+        if not (current_txn.is_finite() and usage.is_finite()):
+            return {
+                "verified": False,
+                "error": "BLOCKED: Remittance verification requires finite amount_usd and financial_year_usage values."
             }
         
         # 1. Prohibited Transactions Check (Schedule I)
@@ -43,11 +49,14 @@ class RemittanceGuard:
         """
         Deterministically calculates Tax Collected at Source (TCS).
         Rule: Education (Loan) = 0.5%, Education (Self) = 5%, Other = 20%
+        Returns a Decimal and raises ValueError on invalid numeric input.
         """
         try:
             amt = Decimal(str(amount_inr))
         except InvalidOperation as exc:
             raise ValueError("amount_inr must be numeric for TCS calculation.") from exc
+        if not amt.is_finite():
+            raise ValueError("amount_inr must be a finite number for TCS calculation.")
         threshold = Decimal("700000") # 7 Lakhs exemption
         
         if amt <= threshold:

--- a/qwed_tax/guards/tds_guard.py
+++ b/qwed_tax/guards/tds_guard.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Dict, Any
 
 class TDSGuard:
@@ -25,8 +25,14 @@ class TDSGuard:
         if not rule:
             return {"verified": True, "deduction": "0", "note": "No TDS rule found for category"}
 
-        inv_amt = Decimal(str(invoice_amount))
-        ytd_amt = Decimal(str(ytd_payment))
+        try:
+            inv_amt = Decimal(str(invoice_amount))
+            ytd_amt = Decimal(str(ytd_payment))
+        except InvalidOperation:
+            return {
+                "verified": False,
+                "error": "TDS verification requires numeric invoice_amount and ytd_payment values."
+            }
         
         total_exposure = inv_amt + ytd_amt
         threshold = Decimal(str(rule["threshold"]))

--- a/qwed_tax/guards/tds_guard.py
+++ b/qwed_tax/guards/tds_guard.py
@@ -33,6 +33,11 @@ class TDSGuard:
                 "verified": False,
                 "error": "TDS verification requires numeric invoice_amount and ytd_payment values."
             }
+        if not (inv_amt.is_finite() and ytd_amt.is_finite()):
+            return {
+                "verified": False,
+                "error": "TDS verification requires finite invoice_amount and ytd_payment values."
+            }
         
         total_exposure = inv_amt + ytd_amt
         threshold = Decimal(str(rule["threshold"]))

--- a/qwed_tax/verifier.py
+++ b/qwed_tax/verifier.py
@@ -324,12 +324,13 @@ class TaxPreFlight:
             report["blocks"].append(tds_check["error"])
             return
 
-        if tds_check.get("deduction") and Decimal(tds_check["deduction"]) > 0:
+        deduction = tds_check.get("deduction")
+        if deduction is not None and Decimal(deduction) > 0:
             report["allowed"] = False
             report["advisories"] = report.get("advisories", [])
-            report["advisories"].append(f"TDS Required: Deduct {tds_check['deduction']} from payment.")
+            report["advisories"].append(f"TDS Required: Deduct {deduction} from payment.")
             report["blocks"].append(
-                f"Invoice payment requires TDS deduction of {tds_check['deduction']} before execution."
+                f"Invoice payment requires TDS deduction of {deduction} before execution."
             )
 
 class TaxVerifier:

--- a/qwed_tax/verifier.py
+++ b/qwed_tax/verifier.py
@@ -139,14 +139,17 @@ class TaxPreFlight:
         """
         if not isinstance(intent, dict) or not intent:
             return self._blocked_report(
-                "TaxPreFlight requires a non-empty intent payload with an explicit action."
+                "TaxPreFlight requires a non-empty intent payload with an explicit action.",
+                action=None,
             )
 
+        requested_action = intent.get("action")
         canonical_action = self._normalize_action(intent.get("action"))
         if canonical_action is None:
             supported_actions = ", ".join(sorted(self._ACTION_CHECKS))
             return self._blocked_report(
-                f"TaxPreFlight requires a supported action. Supported actions: {supported_actions}."
+                f"TaxPreFlight requires a supported action. Supported actions: {supported_actions}.",
+                action=requested_action,
             )
 
         report = {
@@ -195,7 +198,7 @@ class TaxPreFlight:
         selected = []
         for check in checks:
             trigger_fields = check.get("trigger", check["required"])
-            if not any(self._has_field(intent, field) for field in trigger_fields):
+            if not all(self._has_field(intent, field) for field in trigger_fields):
                 continue
 
             predicate_name = check.get("supported_if")
@@ -225,8 +228,8 @@ class TaxPreFlight:
             current = current[part]
         return current is not None and current != ""
 
-    def _blocked_report(self, message: str) -> Dict[str, Any]:
-        return {"allowed": False, "blocks": [message], "checks_run": []}
+    def _blocked_report(self, message: str, action: Any = None) -> Dict[str, Any]:
+        return {"allowed": False, "action": action, "blocks": [message], "checks_run": []}
 
     def _supports_startup_valuation(self, intent: Dict[str, Any]) -> bool:
         return intent.get("investment_round") == "convertible_note"
@@ -316,9 +319,18 @@ class TaxPreFlight:
             intent["amount"],
             intent["ytd_payment"]
         )
+        if not tds_check["verified"]:
+            report["allowed"] = False
+            report["blocks"].append(tds_check["error"])
+            return
+
         if tds_check.get("deduction") and Decimal(tds_check["deduction"]) > 0:
+            report["allowed"] = False
             report["advisories"] = report.get("advisories", [])
             report["advisories"].append(f"TDS Required: Deduct {tds_check['deduction']} from payment.")
+            report["blocks"].append(
+                f"Invoice payment requires TDS deduction of {tds_check['deduction']} before execution."
+            )
 
 class TaxVerifier:
     """

--- a/qwed_tax/verifier.py
+++ b/qwed_tax/verifier.py
@@ -21,6 +21,101 @@ class TaxPreFlight:
     Runs generic deterministic checks (Classification, Nexus) BEFORE
     heavy payroll or logic execution.
     """
+    _ACTION_ALIASES = {
+        "hire_worker": "hire",
+        "worker_classification": "hire",
+        "sales_tax_check": "economic_nexus",
+        "sales_tax_assessment": "economic_nexus",
+    }
+
+    _ACTION_CHECKS = {
+        "hire": [
+            {
+                "name": "worker_classification",
+                "required": (
+                    "worker_type",
+                    "worker_facts.provides_tools",
+                    "worker_facts.reimburses_expenses",
+                    "worker_facts.indefinite_relationship",
+                ),
+                "handler": "_check_worker_classification",
+            }
+        ],
+        "economic_nexus": [
+            {
+                "name": "economic_nexus",
+                "required": (
+                    "state",
+                    "sales_data.amount",
+                    "sales_data.transactions",
+                    "tax_decision",
+                ),
+                "handler": "_check_economic_nexus",
+            }
+        ],
+        "trade_tax": [
+            {
+                "name": "trader_setoff",
+                "trigger": ("loss_head", "offset_head", "loss_amount"),
+                "required": ("loss_head", "offset_head", "loss_amount"),
+                "handler": "_check_trader_setoff",
+            },
+            {
+                "name": "capital_gains",
+                "trigger": ("asset_type", "dates", "claimed_rate"),
+                "required": ("asset_type", "dates.buy", "dates.sell", "claimed_rate"),
+                "handler": "_check_capital_gains",
+            },
+        ],
+        "corporate_action": [
+            {
+                "name": "corporate_loans",
+                "trigger": ("lender_type", "borrower_role", "interest_rate", "market_rate"),
+                "required": ("lender_type", "borrower_role", "interest_rate", "market_rate"),
+                "handler": "_check_corporate_loans",
+            },
+            {
+                "name": "startup_valuation",
+                "trigger": (
+                    "investment_round",
+                    "investment_amount",
+                    "cap_price",
+                    "discount",
+                    "next_round_price",
+                ),
+                "required": (
+                    "investment_round",
+                    "investment_amount",
+                    "cap_price",
+                    "discount",
+                    "next_round_price",
+                ),
+                "handler": "_check_startup_valuation",
+            },
+        ],
+        "remit_money": [
+            {
+                "name": "international_remittance",
+                "required": ("remittance_amount_usd", "purpose", "fy_usage"),
+                "handler": "_check_international_remittance",
+            }
+        ],
+        "expense_claim": [
+            {
+                "name": "expense_itc",
+                "required": ("expense_category", "amount", "tax_paid"),
+                "handler": "_check_expense_itc",
+            }
+        ],
+        "pay_invoice": [
+            {
+                "name": "invoice_tds",
+                "required": ("service_type", "amount", "ytd_payment"),
+                "handler": "_check_invoice_tds",
+            }
+        ],
+    }
+
     def __init__(self):
         self.classifier = ClassificationGuard()
         self.nexus = NexusGuard()
@@ -36,28 +131,103 @@ class TaxPreFlight:
         """
         The 'Pre-Flight' Check for Agentic Finance.
         intent = {
-            "action": "pay_invoice" | "trade_tax" | "corporate_action" | "remit_money" | "expense_claim",
+            "action": "hire" | "economic_nexus" | "trade_tax" | "corporate_action" |
+                      "remit_money" | "expense_claim" | "pay_invoice",
             ...
         }
         """
-        report = {"allowed": True, "blocks": []}
+        if not isinstance(intent, dict) or not intent:
+            return self._blocked_report(
+                "TaxPreFlight requires a non-empty intent payload with an explicit action."
+            )
 
-        self._check_worker_classification(intent, report)
-        self._check_economic_nexus(intent, report)
-        self._check_trader_setoff(intent, report)
-        self._check_capital_gains(intent, report)
-        self._check_corporate_loans(intent, report)
-        self._check_startup_valuation(intent, report)
-        self._check_international_remittance(intent, report)
-        self._check_expense_and_tds(intent, report)
+        canonical_action = self._normalize_action(intent.get("action"))
+        if canonical_action is None:
+            supported_actions = ", ".join(sorted(self._ACTION_CHECKS))
+            return self._blocked_report(
+                f"TaxPreFlight requires a supported action. Supported actions: {supported_actions}."
+            )
+
+        report = {
+            "allowed": True,
+            "action": canonical_action,
+            "blocks": [],
+            "checks_run": [],
+        }
+
+        selected_checks = self._select_checks(canonical_action, intent)
+        if not selected_checks:
+            report["allowed"] = False
+            report["blocks"].append(self._format_missing_claim_message(canonical_action))
+            return report
+
+        for check in selected_checks:
+            missing_fields = self._missing_fields(intent, check["required"])
+            if missing_fields:
+                report["allowed"] = False
+                report["blocks"].append(
+                    f"Action '{canonical_action}' is missing required fields for "
+                    f"{check['name']}: {', '.join(missing_fields)}."
+                )
+                return report
+
+        for check in selected_checks:
+            report["checks_run"].append(check["name"])
+            getattr(self, check["handler"])(intent, report)
+
+        if not report["checks_run"]:
+            report["allowed"] = False
+            report["blocks"].append(
+                f"Action '{canonical_action}' did not execute any verification checks."
+            )
 
         return report
 
     # ---- extracted checks (each keeps complexity flat) ----
 
+    def _normalize_action(self, action: Any) -> str | None:
+        if not isinstance(action, str) or not action.strip():
+            return None
+        normalized = action.strip().lower().replace(" ", "_")
+        normalized = self._ACTION_ALIASES.get(normalized, normalized)
+        return normalized if normalized in self._ACTION_CHECKS else None
+
+    def _select_checks(self, action: str, intent: Dict[str, Any]) -> list[Dict[str, Any]]:
+        checks = self._ACTION_CHECKS[action]
+        if len(checks) == 1:
+            return checks
+
+        selected = []
+        for check in checks:
+            trigger_fields = check.get("trigger", check["required"])
+            if any(self._has_field(intent, field) for field in trigger_fields):
+                selected.append(check)
+        return selected
+
+    def _format_missing_claim_message(self, action: str) -> str:
+        options = []
+        for check in self._ACTION_CHECKS[action]:
+            options.append(f"{check['name']} ({', '.join(check['required'])})")
+        return (
+            f"Action '{action}' did not include a complete verifiable claim. "
+            f"Supported claim shapes: {'; '.join(options)}."
+        )
+
+    def _missing_fields(self, payload: Dict[str, Any], fields: tuple[str, ...]) -> list[str]:
+        return [field for field in fields if not self._has_field(payload, field)]
+
+    def _has_field(self, payload: Dict[str, Any], field_path: str) -> bool:
+        current: Any = payload
+        for part in field_path.split("."):
+            if not isinstance(current, dict) or part not in current:
+                return False
+            current = current[part]
+        return current is not None and current != ""
+
+    def _blocked_report(self, message: str) -> Dict[str, Any]:
+        return {"allowed": False, "blocks": [message], "checks_run": []}
+
     def _check_worker_classification(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        if "worker_facts" not in intent or "worker_type" not in intent:
-            return
         class_check = self.classifier.verify_classification_claim(
             intent["worker_type"], intent["worker_facts"]
         )
@@ -66,25 +236,20 @@ class TaxPreFlight:
             report["blocks"].append(class_check["error"])
 
     def _check_economic_nexus(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        if "sales_data" not in intent or "state" not in intent:
-            return
-        tax_decision = intent.get("tax_decision", "no_tax")
         nexus_check = self.nexus.check_nexus_liability(
             intent["state"],
-            intent["sales_data"].get("amount", 0),
-            intent["sales_data"].get("transactions", 0),
-            tax_decision
+            intent["sales_data"]["amount"],
+            intent["sales_data"]["transactions"],
+            intent["tax_decision"],
         )
         if not nexus_check["verified"]:
             report["allowed"] = False
             report["blocks"].append(nexus_check["error"])
 
     def _check_trader_setoff(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        if "loss_head" not in intent or "offset_head" not in intent:
-            return
         setoff = self.speculation.verify_setoff(
             intent["loss_head"],
-            intent.get("loss_amount", 0),
+            intent["loss_amount"],
             intent["offset_head"]
         )
         if not setoff["verified"]:
@@ -92,78 +257,66 @@ class TaxPreFlight:
             report["blocks"].append(setoff["error"] + " " + setoff.get("fix", ""))
 
     def _check_capital_gains(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        if "asset_type" not in intent or "dates" not in intent:
-            return
         dates = intent["dates"]
-        if "buy" not in dates or "sell" not in dates:
-            report["allowed"] = False
-            report["blocks"].append("Capital gains checks require both buy and sell dates.")
-            return
         term = self.cg.determine_term(dates["buy"], dates["sell"], intent["asset_type"])
-        if "claimed_rate" not in intent:
-            return
         rate_check = self.cg.verify_tax_rate(intent["asset_type"], term, intent["claimed_rate"])
         if not rate_check["verified"]:
             report["allowed"] = False
-            report["blocks"].append(rate_check["error"])
+            report["blocks"].append(rate_check.get("error", "Capital gains verification failed."))
 
     def _check_corporate_loans(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        if "lender_type" not in intent or "borrower_role" not in intent:
-            return
         loan_check = self.related_party.verify_loan_compliance(
             intent["lender_type"],
             intent["borrower_role"],
-            intent.get("interest_rate", 0),
-            intent.get("market_rate", 0)
+            intent["interest_rate"],
+            intent["market_rate"]
         )
         if not loan_check["verified"]:
             report["allowed"] = False
             report["blocks"].append(loan_check["message"])
 
     def _check_startup_valuation(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        if "investment_round" not in intent or intent["investment_round"] != "convertible_note":
+        if intent["investment_round"] != "convertible_note":
+            report["allowed"] = False
+            report["blocks"].append(
+                "Startup valuation verification currently supports only convertible_note rounds."
+            )
             return
         val_check = self.valuation.verify_conversion(
-            intent.get("investment_amount", "0"),
-            intent.get("cap_price", "0"),
-            intent.get("discount", "0"),
-            intent.get("next_round_price", "0")
+            intent["investment_amount"],
+            intent["cap_price"],
+            intent["discount"],
+            intent["next_round_price"]
         )
         if not val_check["verified"]:
             report["allowed"] = False
             report["blocks"].append(val_check["error"])
 
     def _check_international_remittance(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        if "remittance_amount_usd" not in intent or "purpose" not in intent:
-            return
         remit_check = self.remittance.verify_lrs_limit(
             intent["remittance_amount_usd"],
             intent["purpose"],
-            intent.get("fy_usage", 0)
+            intent["fy_usage"]
         )
         if not remit_check["verified"]:
             report["allowed"] = False
             report["blocks"].append(remit_check["error"])
 
-    def _check_expense_and_tds(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        # ITC Check (only when both keys present)
-        if "expense_category" in intent and "amount" in intent:
-            itc_check = self.indirect_tax.verify_itc_eligibility(
-                intent["expense_category"],
-                intent.get("amount", 0),
-                intent.get("tax_paid", 0)
-            )
-            if not itc_check["verified"]:
-                report["allowed"] = False
-                report["blocks"].append(itc_check["reason"])
+    def _check_expense_itc(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
+        itc_check = self.indirect_tax.verify_itc_eligibility(
+            intent["expense_category"],
+            intent["amount"],
+            intent["tax_paid"]
+        )
+        if not itc_check["verified"]:
+            report["allowed"] = False
+            report["blocks"].append(itc_check["reason"])
 
-        # TDS Check (if service type provided)
-        if "service_type" not in intent or "amount" not in intent:
-            return
+    def _check_invoice_tds(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
         tds_check = self.withholding.calculate_deduction(
             intent["service_type"],
-            intent.get("amount", 0),
-            intent.get("ytd_payment", 0)
+            intent["amount"],
+            intent["ytd_payment"]
         )
         if tds_check.get("deduction") and Decimal(tds_check["deduction"]) > 0:
             report["advisories"] = report.get("advisories", [])

--- a/qwed_tax/verifier.py
+++ b/qwed_tax/verifier.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, ClassVar, Dict
 from decimal import Decimal
 from .guards.speculation_guard import SpeculationGuard
 from .guards.capital_gains_guard import CapitalGainsGuard
@@ -21,14 +21,14 @@ class TaxPreFlight:
     Runs generic deterministic checks (Classification, Nexus) BEFORE
     heavy payroll or logic execution.
     """
-    _ACTION_ALIASES = {
+    _ACTION_ALIASES: ClassVar[dict[str, str]] = {
         "hire_worker": "hire",
         "worker_classification": "hire",
         "sales_tax_check": "economic_nexus",
         "sales_tax_assessment": "economic_nexus",
     }
 
-    _ACTION_CHECKS = {
+    _ACTION_CHECKS: ClassVar[dict[str, list[dict[str, Any]]]] = {
         "hire": [
             {
                 "name": "worker_classification",
@@ -90,6 +90,7 @@ class TaxPreFlight:
                     "discount",
                     "next_round_price",
                 ),
+                "supported_if": "_supports_startup_valuation",
                 "handler": "_check_startup_valuation",
             },
         ],
@@ -175,12 +176,6 @@ class TaxPreFlight:
             report["checks_run"].append(check["name"])
             getattr(self, check["handler"])(intent, report)
 
-        if not report["checks_run"]:
-            report["allowed"] = False
-            report["blocks"].append(
-                f"Action '{canonical_action}' did not execute any verification checks."
-            )
-
         return report
 
     # ---- extracted checks (each keeps complexity flat) ----
@@ -200,8 +195,14 @@ class TaxPreFlight:
         selected = []
         for check in checks:
             trigger_fields = check.get("trigger", check["required"])
-            if any(self._has_field(intent, field) for field in trigger_fields):
-                selected.append(check)
+            if not any(self._has_field(intent, field) for field in trigger_fields):
+                continue
+
+            predicate_name = check.get("supported_if")
+            if predicate_name and not getattr(self, predicate_name)(intent):
+                continue
+
+            selected.append(check)
         return selected
 
     def _format_missing_claim_message(self, action: str) -> str:
@@ -226,6 +227,9 @@ class TaxPreFlight:
 
     def _blocked_report(self, message: str) -> Dict[str, Any]:
         return {"allowed": False, "blocks": [message], "checks_run": []}
+
+    def _supports_startup_valuation(self, intent: Dict[str, Any]) -> bool:
+        return intent.get("investment_round") == "convertible_note"
 
     def _check_worker_classification(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
         class_check = self.classifier.verify_classification_claim(
@@ -276,12 +280,6 @@ class TaxPreFlight:
             report["blocks"].append(loan_check["message"])
 
     def _check_startup_valuation(self, intent: Dict[str, Any], report: Dict[str, Any]) -> None:
-        if intent["investment_round"] != "convertible_note":
-            report["allowed"] = False
-            report["blocks"].append(
-                "Startup valuation verification currently supports only convertible_note rounds."
-            )
-            return
         val_check = self.valuation.verify_conversion(
             intent["investment_amount"],
             intent["cap_price"],

--- a/tests/test_guards_coverage.py
+++ b/tests/test_guards_coverage.py
@@ -392,6 +392,20 @@ class TestTaxPreFlightAudit:
         assert report["checks_run"] == ["international_remittance"]
         assert "requires numeric" in report["blocks"][0]
 
+    def test_remittance_non_finite_values_block_without_crashing(self):
+        """Remittance checks must fail closed on NaN/Infinity values."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "remit_money",
+                "remittance_amount_usd": float("inf"),
+                "purpose": "education",
+                "fy_usage": float("nan"),
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["international_remittance"]
+        assert "requires finite" in report["blocks"][0]
+
     def test_remittance_limit_violation_runs_and_blocks(self):
         """Remittance checks should block when annual limit is exceeded."""
         report = self.pf.audit_transaction(
@@ -435,6 +449,20 @@ class TestTaxPreFlightAudit:
         assert report["allowed"] is False
         assert report["checks_run"] == ["invoice_tds"]
         assert "requires numeric" in report["blocks"][0]
+
+    def test_pay_invoice_non_finite_values_block_without_crashing(self):
+        """Pay-invoice checks must fail closed on NaN/Infinity values."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "pay_invoice",
+                "service_type": "professional_fees",
+                "amount": float("nan"),
+                "ytd_payment": float("inf"),
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["invoice_tds"]
+        assert "requires finite" in report["blocks"][0]
 
     def test_hire_action_runs_and_blocks_misclassification(self):
         """Once required fields are present, the derived classification should gate allow."""

--- a/tests/test_guards_coverage.py
+++ b/tests/test_guards_coverage.py
@@ -277,6 +277,94 @@ class TestTaxPreFlightAudit:
         assert report["checks_run"] == ["expense_itc"]
         assert report["blocks"] == []
 
+    def test_economic_nexus_violation_runs_and_blocks(self):
+        """Economic nexus claims should run and block when thresholds are crossed."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "economic_nexus",
+                "state": "NY",
+                "sales_data": {"amount": 500001, "transactions": 10},
+                "tax_decision": "no_tax",
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["economic_nexus"]
+        assert "Nexus Violation" in report["blocks"][0]
+
+    def test_trade_tax_setoff_runs_and_blocks_illegal_offset(self):
+        """Trade tax set-off claims should block speculative loss misuse."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "trade_tax",
+                "loss_head": "intraday loss",
+                "loss_amount": 2500,
+                "offset_head": "futures profit",
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["trader_setoff"]
+        assert "Illegal Set-Off" in report["blocks"][0]
+
+    def test_trade_tax_capital_gains_runs_and_blocks_rate_mismatch(self):
+        """Capital gains claims should run and block incorrect statutory rates."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "trade_tax",
+                "asset_type": "equity",
+                "dates": {"buy": "2022-01-01", "sell": "2024-02-01"},
+                "claimed_rate": "10%",
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["capital_gains"]
+        assert "Rate Mismatch" in report["blocks"][0]
+
+    def test_corporate_action_loan_check_runs_and_blocks(self):
+        """Corporate loan compliance should block prohibited borrower roles."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "corporate_action",
+                "lender_type": "company",
+                "borrower_role": "director",
+                "interest_rate": 10.0,
+                "market_rate": 8.0,
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["corporate_loans"]
+        assert "Section 185" in report["blocks"][0]
+
+    def test_corporate_action_unsupported_startup_claim_blocks_without_fake_success(self):
+        """Unsupported startup valuation rounds must fail closed instead of pretending to verify."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "corporate_action",
+                "investment_round": "series_a",
+                "investment_amount": "100000",
+                "cap_price": "8",
+                "discount": "0.2",
+                "next_round_price": "10",
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == []
+        assert "did not include a complete verifiable claim" in report["blocks"][0]
+        assert "startup_valuation" in report["blocks"][0]
+
+    def test_remittance_limit_violation_runs_and_blocks(self):
+        """Remittance checks should block when annual limit is exceeded."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "remit_money",
+                "remittance_amount_usd": 10000,
+                "purpose": "education",
+                "fy_usage": 245001,
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["international_remittance"]
+        assert "exceeds LRS limit" in report["blocks"][0]
+
     def test_hire_action_runs_and_blocks_misclassification(self):
         """Once required fields are present, the derived classification should gate allow."""
         report = self.pf.audit_transaction(

--- a/tests/test_guards_coverage.py
+++ b/tests/test_guards_coverage.py
@@ -1,5 +1,7 @@
-"""Tests covering new/changed code paths for SonarCloud coverage."""
+"""Tests covering new and changed code paths for guard coverage."""
+
 from decimal import Decimal
+
 from qwed_tax.guards.dtaa_guard import DTAAGuard
 from qwed_tax.guards.indirect_tax_guard import InputCreditGuard
 from qwed_tax.jurisdictions.us.form1099_guard import Form1099Guard
@@ -8,28 +10,29 @@ from qwed_tax.verifier import TaxPreFlight
 
 
 # ------------------------------------------------------------------
-# DTAAGuard — treaty rate logic
+# DTAAGuard - treaty rate logic
 # ------------------------------------------------------------------
+
 
 class TestDTAAGuard:
     def setup_method(self):
         self.guard = DTAAGuard()
 
     def test_ftc_without_treaty_rate(self):
-        """No treaty rate → simple min(foreign_tax, home_tax)."""
+        """No treaty rate means simple min(foreign_tax, home_tax)."""
         res = self.guard.verify_foreign_tax_credit(1000, 100, 30.0)
         assert res["allowable_credit"] == 100.0
         assert res["excess_tax_lapsed"] == 0.0
 
     def test_ftc_capped_by_home_tax(self):
-        """Foreign tax > home tax → capped at home."""
+        """Foreign tax above home tax is capped at the home liability."""
         res = self.guard.verify_foreign_tax_credit(1000, 200, 15.0)
         assert res["allowable_credit"] == 150.0
         assert res["excess_tax_lapsed"] == 50.0
         assert "FTC Capped" in res["message"]
 
     def test_ftc_with_treaty_rate_caps(self):
-        """Treaty rate 10% on 1000 = 100 cap, even though home allows 300."""
+        """Treaty rate cap applies before the home-tax cap."""
         res = self.guard.verify_foreign_tax_credit(
             1000, 200, 30.0, foreign_tax_limit_rate=10.0
         )
@@ -38,7 +41,7 @@ class TestDTAAGuard:
         assert "Treaty" in res["message"]
 
     def test_ftc_treaty_rate_no_effect_when_generous(self):
-        """Treaty rate 50% on 1000 = 500 cap, but foreign tax < home tax → full credit."""
+        """Generous treaty rate should not reduce an already valid full credit."""
         res = self.guard.verify_foreign_tax_credit(
             1000, 100, 30.0, foreign_tax_limit_rate=50.0
         )
@@ -47,8 +50,9 @@ class TestDTAAGuard:
 
 
 # ------------------------------------------------------------------
-# InputCreditGuard — ITC eligibility + GSTIN
+# InputCreditGuard - ITC eligibility + GSTIN
 # ------------------------------------------------------------------
+
 
 class TestInputCreditGuard:
     def setup_method(self):
@@ -79,7 +83,7 @@ class TestInputCreditGuard:
         assert res["eligible_itc"] == 5400
 
     def test_gift_at_threshold_blocked(self):
-        """Gift at exactly 50,000 should be blocked (< 50000 is the condition)."""
+        """Gift at exactly 50,000 should be blocked because the rule is amount < 50,000."""
         res = self.guard.verify_itc_eligibility("gift to employee", 50000, 9000)
         assert res["verified"] is False
 
@@ -98,8 +102,9 @@ class TestInputCreditGuard:
 
 
 # ------------------------------------------------------------------
-# Form1099Guard — filing requirements
+# Form1099Guard - filing requirements
 # ------------------------------------------------------------------
+
 
 class TestForm1099Guard:
     def setup_method(self):
@@ -110,7 +115,7 @@ class TestForm1099Guard:
             contractor_id="C001",
             payment_type=PaymentType.NON_EMPLOYEE_COMPENSATION,
             amount=Decimal("700.00"),
-            calendar_year=2024
+            calendar_year=2024,
         )
         res = self.guard.verify_filing_requirement(payment)
         assert res["filing_required"] is True
@@ -121,7 +126,7 @@ class TestForm1099Guard:
             contractor_id="C002",
             payment_type=PaymentType.NON_EMPLOYEE_COMPENSATION,
             amount=Decimal("500.00"),
-            calendar_year=2024
+            calendar_year=2024,
         )
         res = self.guard.verify_filing_requirement(payment)
         assert res["filing_required"] is False
@@ -131,7 +136,7 @@ class TestForm1099Guard:
             contractor_id="C003",
             payment_type=PaymentType.RENT,
             amount=Decimal("600.00"),
-            calendar_year=2024
+            calendar_year=2024,
         )
         res = self.guard.verify_filing_requirement(payment)
         assert res["filing_required"] is True
@@ -142,7 +147,7 @@ class TestForm1099Guard:
             contractor_id="C004",
             payment_type=PaymentType.ROYALTIES,
             amount=Decimal("15.00"),
-            calendar_year=2024
+            calendar_year=2024,
         )
         res = self.guard.verify_filing_requirement(payment)
         assert res["filing_required"] is True
@@ -152,7 +157,7 @@ class TestForm1099Guard:
             contractor_id="C005",
             payment_type=PaymentType.ROYALTIES,
             amount=Decimal("5.00"),
-            calendar_year=2024
+            calendar_year=2024,
         )
         res = self.guard.verify_filing_requirement(payment)
         assert res["filing_required"] is False
@@ -162,7 +167,7 @@ class TestForm1099Guard:
             contractor_id="C006",
             payment_type=PaymentType.ATTORNEY_FEES,
             amount=Decimal("1000.00"),
-            calendar_year=2024
+            calendar_year=2024,
         )
         res = self.guard.verify_filing_requirement(payment)
         assert res["filing_required"] is True
@@ -170,42 +175,121 @@ class TestForm1099Guard:
 
 
 # ------------------------------------------------------------------
-# TaxPreFlight — audit_transaction extracted methods
+# TaxPreFlight - fail-closed action orchestration
 # ------------------------------------------------------------------
+
 
 class TestTaxPreFlightAudit:
     def setup_method(self):
         self.pf = TaxPreFlight()
 
-    def test_empty_intent_passes(self):
-        """No matching keys → nothing blocked."""
+    def test_empty_intent_blocks(self):
+        """Empty payloads must fail closed instead of silently passing."""
         report = self.pf.audit_transaction({})
+        assert report["allowed"] is False
+        assert report["checks_run"] == []
+        assert "non-empty intent payload" in report["blocks"][0]
+
+    def test_missing_action_blocks_even_with_claim_data(self):
+        """Action is mandatory so sparse payloads cannot silently skip checks."""
+        report = self.pf.audit_transaction(
+            {
+                "expense_category": "office_supplies",
+                "amount": 1000,
+                "tax_paid": 180,
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == []
+        assert "requires a supported action" in report["blocks"][0]
+
+    def test_unknown_action_blocks(self):
+        """Unsupported actions must not fall back to an allow result."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "magic_tax_mode",
+                "expense_category": "office_supplies",
+                "amount": 1000,
+                "tax_paid": 180,
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == []
+        assert "supported action" in report["blocks"][0]
+
+    def test_hire_action_with_misnamed_keys_blocks(self):
+        """Typos in required keys must block instead of skipping classification."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "hire",
+                "worker_type": "1099",
+                "workerFacts": {
+                    "provides_tools": True,
+                    "reimburses_expenses": True,
+                    "indefinite_relationship": True,
+                },
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == []
+        assert "worker_facts.provides_tools" in report["blocks"][0]
+
+    def test_trade_tax_capital_gains_missing_nested_dates_block(self):
+        """Nested required fields must be present before capital gains runs."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "trade_tax",
+                "asset_type": "equity",
+                "dates": {},
+                "claimed_rate": "10%",
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == []
+        assert "dates.buy" in report["blocks"][0]
+        assert "dates.sell" in report["blocks"][0]
+
+    def test_expense_claim_blocked_category_returns_failed_check(self):
+        """A valid action shape should run the relevant check and surface the block."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "expense_claim",
+                "expense_category": "FOOD_AND_BEVERAGE",
+                "amount": 5000,
+                "tax_paid": 900,
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["expense_itc"]
+        assert "ITC is blocked" in report["blocks"][0]
+
+    def test_expense_claim_eligible_runs_and_stays_allowed(self):
+        """A complete supported claim should run one check and remain allowed."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "expense_claim",
+                "expense_category": "office_supplies",
+                "amount": 1000,
+                "tax_paid": 180,
+            }
+        )
         assert report["allowed"] is True
+        assert report["checks_run"] == ["expense_itc"]
         assert report["blocks"] == []
 
-    def test_capital_gains_missing_dates_keys(self):
-        """intent has dates dict but missing buy/sell → block with message."""
-        report = self.pf.audit_transaction({
-            "asset_type": "equity",
-            "dates": {}
-        })
+    def test_hire_action_runs_and_blocks_misclassification(self):
+        """Once required fields are present, the derived classification should gate allow."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "hire",
+                "worker_type": "1099",
+                "worker_facts": {
+                    "provides_tools": True,
+                    "reimburses_expenses": True,
+                    "indefinite_relationship": True,
+                },
+            }
+        )
         assert report["allowed"] is False
-        assert any("buy and sell dates" in b for b in report["blocks"])
-
-    def test_expense_itc_blocked(self):
-        """Blocked expense category → allowed=False."""
-        report = self.pf.audit_transaction({
-            "expense_category": "FOOD_AND_BEVERAGE",
-            "amount": 5000,
-            "tax_paid": 900
-        })
-        assert report["allowed"] is False
-
-    def test_expense_itc_eligible(self):
-        """Eligible category → allowed remains True."""
-        report = self.pf.audit_transaction({
-            "expense_category": "office_supplies",
-            "amount": 1000,
-            "tax_paid": 180
-        })
-        assert report["allowed"] is True
+        assert report["checks_run"] == ["worker_classification"]
+        assert "Misclassification Risk" in report["blocks"][0]

--- a/tests/test_guards_coverage.py
+++ b/tests/test_guards_coverage.py
@@ -183,10 +183,20 @@ class TestTaxPreFlightAudit:
     def setup_method(self):
         self.pf = TaxPreFlight()
 
+    def test_non_dict_intents_block(self):
+        """Non-dict payloads must fail closed with a consistent report shape."""
+        for bad_intent in (None, [], "bad"):
+            report = self.pf.audit_transaction(bad_intent)
+            assert report["allowed"] is False
+            assert report["action"] is None
+            assert report["checks_run"] == []
+            assert "non-empty intent payload" in report["blocks"][0]
+
     def test_empty_intent_blocks(self):
         """Empty payloads must fail closed instead of silently passing."""
         report = self.pf.audit_transaction({})
         assert report["allowed"] is False
+        assert report["action"] is None
         assert report["checks_run"] == []
         assert "non-empty intent payload" in report["blocks"][0]
 
@@ -200,6 +210,7 @@ class TestTaxPreFlightAudit:
             }
         )
         assert report["allowed"] is False
+        assert report["action"] is None
         assert report["checks_run"] == []
         assert "requires a supported action" in report["blocks"][0]
 
@@ -214,6 +225,7 @@ class TestTaxPreFlightAudit:
             }
         )
         assert report["allowed"] is False
+        assert report["action"] == "magic_tax_mode"
         assert report["checks_run"] == []
         assert "supported action" in report["blocks"][0]
 
@@ -319,6 +331,21 @@ class TestTaxPreFlightAudit:
         assert report["checks_run"] == ["capital_gains"]
         assert "Rate Mismatch" in report["blocks"][0]
 
+    def test_trade_tax_stray_loss_key_does_not_select_wrong_check(self):
+        """Capital gains payloads should not co-select trader_setoff from a stray key."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "trade_tax",
+                "asset_type": "equity",
+                "dates": {"buy": "2022-01-01", "sell": "2024-02-01"},
+                "claimed_rate": "10%",
+                "loss_head": "intraday loss",
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["capital_gains"]
+        assert "Rate Mismatch" in report["blocks"][0]
+
     def test_corporate_action_loan_check_runs_and_blocks(self):
         """Corporate loan compliance should block prohibited borrower roles."""
         report = self.pf.audit_transaction(
@@ -351,6 +378,20 @@ class TestTaxPreFlightAudit:
         assert "did not include a complete verifiable claim" in report["blocks"][0]
         assert "startup_valuation" in report["blocks"][0]
 
+    def test_remittance_non_numeric_values_block_without_crashing(self):
+        """Remittance checks must fail closed on non-numeric values."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "remit_money",
+                "remittance_amount_usd": "pending",
+                "purpose": "education",
+                "fy_usage": "unknown",
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["international_remittance"]
+        assert "requires numeric" in report["blocks"][0]
+
     def test_remittance_limit_violation_runs_and_blocks(self):
         """Remittance checks should block when annual limit is exceeded."""
         report = self.pf.audit_transaction(
@@ -364,6 +405,36 @@ class TestTaxPreFlightAudit:
         assert report["allowed"] is False
         assert report["checks_run"] == ["international_remittance"]
         assert "exceeds LRS limit" in report["blocks"][0]
+
+    def test_pay_invoice_tds_requirement_blocks_and_adds_advisory(self):
+        """Invoice payments should block until required TDS is deducted."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "pay_invoice",
+                "service_type": "professional_fees",
+                "amount": 50000,
+                "ytd_payment": 0,
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["invoice_tds"]
+        assert "advisories" in report
+        assert "TDS Required" in report["advisories"][0]
+        assert "requires TDS deduction" in report["blocks"][0]
+
+    def test_pay_invoice_non_numeric_values_block_without_crashing(self):
+        """Pay-invoice checks must fail closed on non-numeric values."""
+        report = self.pf.audit_transaction(
+            {
+                "action": "pay_invoice",
+                "service_type": "professional_fees",
+                "amount": "pending",
+                "ytd_payment": "carry_forward",
+            }
+        )
+        assert report["allowed"] is False
+        assert report["checks_run"] == ["invoice_tds"]
+        assert "requires numeric" in report["blocks"][0]
 
     def test_hire_action_runs_and_blocks_misclassification(self):
         """Once required fields are present, the derived classification should gate allow."""


### PR DESCRIPTION
## Summary
This PR fixes issue #14 by closing the TaxPreFlight fail-open boundary.

Previously, `TaxPreFlight.audit_transaction()` started from `allowed=True` and silently skipped checks when required keys were missing or misnamed. That allowed empty, sparse, or malformed intents to bypass preflight and still return a success-like allow result.

This change moves TaxPreFlight to a fail-closed model:
- a non-empty intent with a supported `action` is now required
- only action-relevant checks run
- missing required fields block before any guard executes
- reports now include `checks_run` so it is clear what was actually verified

## What changed
- added explicit action normalization and action-specific check routing
- added required-field validation before guard execution
- blocked empty payloads, missing actions, unsupported actions, and incomplete claim shapes
- split expense/TDS routing into explicit action-bound checks
- updated regression tests to assert the new fail-closed contract

## Validation
- `C:\Users\rahul\AppData\Local\Programs\Python\Python311\python.exe -m pytest -q`
- result: `30 passed`

## Why
TaxPreFlight is a verification boundary. Missing or malformed inputs must not be treated as safe to allow.

This PR ensures TaxPreFlight only allows a transaction when the relevant checks actually ran and passed.

Closes #14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonicalizes and validates submitted action types, reports the resolved action and exact checks run.

* **Bug Fixes**
  * Enforces required-field validation up-front, preventing partial/defaulted processing and providing clear block messages for malformed/empty intents.
  * Stronger numeric-input validation for remittance and TDS flows; invalid numbers now produce explicit block/error messages and avoid incorrect calculations.
  * TDS path now blocks when underlying calculation is unverified or a positive deduction is required.

* **Tests**
  * Expanded fail-closed tests covering per-action validation, blocking messages, and check coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->