### PR TITLE
docs: harden fail-closed contract in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,26 @@ Thank you for your interest in contributing to `qwed-tax`! We are building the w
 - We implement the **Law**, not statistical likelihoods.
 - Every check must return a binary `True` (Allowed) or `False` (Blocked), with exact reasoning.
 
-## 🛠️ Development Setup
+## 🔐 Security Contract for Tests & Docs (Fail-Closed)
+Tests and documentation are part of the verifier boundary contract.
+
+- Missing, ambiguous, unknown, or unsupported inputs **must fail closed**.
+- Tests must not normalize silent pass behavior (e.g., empty preflight payloads returning allowed).
+- Documentation/examples must not imply "best effort" or skipped checks are acceptable verification.
+- A claim should be described as verified only when:
+  1) a supported `action` is provided, and
+  2) at least one deterministic check actually executes.
+
+If a behavior is insecure, tests/docs must describe it as a bug to fix, not intended behavior.
+
+### PR checklist add-on (required)
+For changes touching verifier boundaries, ensure PR includes:
+- [ ] fail-closed tests for missing/invalid/unsupported inputs
+- [ ] explicit expected-vs-actual verification reasoning in test names or docstrings
+- [ ] documentation updates matching actual enforced behavior
+- [ ] no language that overstates assurance beyond executed checks
+
+## Development Setup
 
 1. **Clone the repo:**
    ```bash

--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ preflight = TaxPreFlight()
 report = preflight.audit_transaction({
     "action": "hire",
     "worker_type": "1099",
-    "worker_facts": {"provides_tools": True, "reimburses_expenses": True}, # Employee traits
+    "worker_facts": {
+        "provides_tools": True,
+        "reimburses_expenses": True,
+        "indefinite_relationship": True
+    }, # Employee traits
     "state": "NY", 
     "sales_data": {"amount": 600000} # Crosses Nexus
 })

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="assets/logo.svg" alt="QWED Logo" width="140" />
+
 # 💸 QWED-Tax
 **Deterministic Verification for Payroll, Tax, and Compliance**
 
@@ -69,6 +71,8 @@ if (!result.allowed) {
    alert(" Compliance Block: " + result.blocks.join(", "));
 }
 ```
+
+> 🔐 **Fail-Closed Contract:** `TaxPreFlight` is strict by design. Missing, ambiguous, or unsupported intent payloads are blocked (`allowed = false`) rather than treated as a successful verification.
 
 ### ⚔️ Why QWED-Tax?
 Unlike calculators (Avalara) or executors (Gusto), QWED is a **Verifier**. We sit *between* the AI and the Execution.
@@ -164,6 +168,7 @@ from qwed_tax.verifier import TaxPreFlight
 
 preflight = TaxPreFlight()
 report = preflight.audit_transaction({
+    "action": "hire",
     "worker_type": "1099",
     "worker_facts": {"provides_tools": True, "reimburses_expenses": True}, # Employee traits
     "state": "NY", 
@@ -173,6 +178,8 @@ report = preflight.audit_transaction({
 if not report["allowed"]:
     print(f"🛑 BLOCKED: {report['blocks']}")
 ```
+
+> ℹ️ A claim is considered verified only when a supported `action` is provided and at least one deterministic check is actually executed.
 
 ## 📂 Examples
 Check the `examples/` directory for runnable scripts:

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <!-- Shield background -->
+  <path d="M50 5 L90 20 L90 50 C90 75 50 95 50 95 C50 95 10 75 10 50 L10 20 Z" 
+        fill="#10b981" opacity="0.2"/>
+  
+  <!-- Shield outline -->
+  <path d="M50 5 L90 20 L90 50 C90 75 50 95 50 95 C50 95 10 75 10 50 L10 20 Z" 
+        fill="none" stroke="#10b981" stroke-width="3"/>
+  
+  <!-- Check mark (verification) -->
+  <path d="M30 50 L45 65 L70 35" 
+        fill="none" stroke="#10b981" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  
+  <!-- Q letter hint (subtle) -->
+  <circle cx="50" cy="48" r="15" fill="none" stroke="#10b981" stroke-width="2" opacity="0.3"/>
+  <path d="M58 56 L68 66" stroke="#10b981" stroke-width="2" stroke-linecap="round" opacity="0.3"/>
+</svg>


### PR DESCRIPTION
## Summary
This PR strengthens repository documentation to reflect QWED's fail-closed, deterministic, zero-trust verifier contract.

## What changed
- Added explicit fail-closed contract language to `README.md` for `TaxPreFlight`:
  - missing/ambiguous/unsupported intents must block (`allowed = false`)
  - verification requires a supported `action` and executed deterministic checks
- Added `assets/logo.svg` (from core QWED branding) and embedded it in README header
- Added a new section in `CONTRIBUTING.md`:
  - **Security Contract for Tests & Docs (Fail-Closed)**
  - PR checklist add-on for verifier-boundary changes to prevent fail-open regressions

## Why
Tests/docs define long-term project contract. This change ensures contributor guidance and public docs consistently reinforce fail-closed boundary behavior.

## Notes
- No verifier logic changes in this PR.
- This is a docs/policy hardening update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security contract specifications clarifying that unsupported, ambiguous, or missing inputs are blocked rather than silently passed through.
  * Updated behavioral documentation to explicitly define when verification claims are applicable based on supported actions and executed checks.
  * Established updated testing and documentation standards to align with enforced security practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-tax/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->