### PR TITLE
feat(gst): validate GSTIN check digit, not just format

### DIFF
--- a/qwed_tax/guards/indirect_tax_guard.py
+++ b/qwed_tax/guards/indirect_tax_guard.py
@@ -69,12 +69,47 @@ class InputCreditGuard:
             "note": "Expense appears eligible for Input Tax Credit.",
         }
 
+    # GSTIN check-digit alphabet: digits 0-9 followed by A-Z (base 36).
+    _GSTIN_CODES = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+    def _gstin_check_digit(self, first_14: str) -> str:
+        """
+        Compute the 15th GSTIN check character from the first 14 characters.
+
+        Algorithm (GSTN spec):
+          - Map each character to its index in [0-9A-Z] (base 36).
+          - Multiply by an alternating factor (1, 2, 1, 2, ... left to right).
+          - For each product, add (product // 36) + (product % 36) to a sum.
+          - check = (36 - (sum % 36)) % 36, mapped back to the alphabet.
+        """
+        total = 0
+        for index, char in enumerate(first_14):
+            value = self._GSTIN_CODES.index(char)
+            factor = 1 if index % 2 == 0 else 2
+            product = value * factor
+            total += (product // 36) + (product % 36)
+        return self._GSTIN_CODES[(36 - (total % 36)) % 36]
+
     def verify_gstin_format(self, gstin: str) -> Dict[str, Any]:
         """
-        Deterministic checksum validation for Indian GSTIN.
-        Format: 22AAAAA0000A1Z5 (15 chars)
+        Deterministic GSTIN validation: structural format plus the 15th-digit
+        checksum (base-36 GSTN algorithm).
+
+        Format: 22AAAAA0000A1Z5 (15 chars). A string that matches the format but
+        carries an incorrect check digit is rejected as a checksum failure.
         """
         pattern = r"^\d{2}[A-Z]{5}\d{4}[A-Z][1-9A-Z]Z[0-9A-Z]$"
         if not re.match(pattern, gstin):
             return {"verified": False, "error": "Invalid GSTIN format."}
+
+        expected_check = self._gstin_check_digit(gstin[:14])
+        if gstin[14] != expected_check:
+            return {
+                "verified": False,
+                "error": (
+                    f"Invalid GSTIN checksum: expected check digit "
+                    f"'{expected_check}', got '{gstin[14]}'."
+                ),
+            }
+
         return {"verified": True}

--- a/qwed_tax/guards/indirect_tax_guard.py
+++ b/qwed_tax/guards/indirect_tax_guard.py
@@ -72,7 +72,8 @@ class InputCreditGuard:
     # GSTIN check-digit alphabet: digits 0-9 followed by A-Z (base 36).
     _GSTIN_CODES = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-    def _gstin_check_digit(self, first_14: str) -> str:
+    @staticmethod
+    def _gstin_check_digit(first_14: str) -> str:
         """
         Compute the 15th GSTIN check character from the first 14 characters.
 
@@ -84,11 +85,11 @@ class InputCreditGuard:
         """
         total = 0
         for index, char in enumerate(first_14):
-            value = self._GSTIN_CODES.index(char)
+            value = InputCreditGuard._GSTIN_CODES.index(char)
             factor = 1 if index % 2 == 0 else 2
             product = value * factor
             total += (product // 36) + (product % 36)
-        return self._GSTIN_CODES[(36 - (total % 36)) % 36]
+        return InputCreditGuard._GSTIN_CODES[(36 - (total % 36)) % 36]
 
     def verify_gstin_format(self, gstin: str) -> Dict[str, Any]:
         """
@@ -102,14 +103,10 @@ class InputCreditGuard:
         if not re.match(pattern, gstin):
             return {"verified": False, "error": "Invalid GSTIN format."}
 
-        expected_check = self._gstin_check_digit(gstin[:14])
-        if gstin[14] != expected_check:
-            return {
-                "verified": False,
-                "error": (
-                    f"Invalid GSTIN checksum: expected check digit "
-                    f"'{expected_check}', got '{gstin[14]}'."
-                ),
-            }
+        # Do not echo the correct check digit back to the caller: revealing it
+        # would turn this validator into an oracle for fabricating GSTINs that
+        # pass both format and checksum checks.
+        if gstin[14] != self._gstin_check_digit(gstin[:14]):
+            return {"verified": False, "error": "Invalid GSTIN checksum."}
 
         return {"verified": True}

--- a/tests/test_guards_coverage.py
+++ b/tests/test_guards_coverage.py
@@ -125,11 +125,13 @@ class TestInputCreditGuard:
         assert "Invalid GSTIN" in res["error"]
 
     def test_gstin_valid_format_wrong_checksum(self):
-        # Matches the structural pattern but the 15th check digit is wrong
-        # (correct check digit for the first 14 chars is 'C', not '5').
+        # Matches the structural pattern but the 15th check digit is wrong.
+        # The error stays generic on purpose (no correct-digit disclosure).
         res = self.guard.verify_gstin_format("22AAAAA0000A1Z5")
         assert res["verified"] is False
         assert "checksum" in res["error"]
+        # The correct check digit must NOT be echoed back (anti-oracle).
+        assert "'C'" not in res["error"]
 
     def test_invalid_numeric_itc_input_blocks(self):
         res = self.guard.verify_itc_eligibility("office supplies", "pending", 180)

--- a/tests/test_guards_coverage.py
+++ b/tests/test_guards_coverage.py
@@ -115,13 +115,21 @@ class TestInputCreditGuard:
         assert res["verified"] is False
 
     def test_gstin_valid(self):
-        res = self.guard.verify_gstin_format("22AAAAA0000A1Z5")
+        # Real-world GSTIN with a correct base-36 check digit.
+        res = self.guard.verify_gstin_format("27AAPFU0939F1ZV")
         assert res["verified"] is True
 
     def test_gstin_invalid(self):
         res = self.guard.verify_gstin_format("INVALID")
         assert res["verified"] is False
         assert "Invalid GSTIN" in res["error"]
+
+    def test_gstin_valid_format_wrong_checksum(self):
+        # Matches the structural pattern but the 15th check digit is wrong
+        # (correct check digit for the first 14 chars is 'C', not '5').
+        res = self.guard.verify_gstin_format("22AAAAA0000A1Z5")
+        assert res["verified"] is False
+        assert "checksum" in res["error"]
 
     def test_invalid_numeric_itc_input_blocks(self):
         res = self.guard.verify_itc_eligibility("office supplies", "pending", 180)


### PR DESCRIPTION
## What

`InputCreditGuard.verify_gstin_format()` previously only matched the GSTIN structural regex, even though its docstring claimed "checksum validation". This implements the actual base-36 GSTN check-digit algorithm so that a string which matches the format but carries an incorrect 15th check digit is correctly rejected.

---

## Why

A regex-only check gives a false sense of validation — any structurally shaped string passes, including typo'd or fabricated GSTINs. GSTIN validation is deterministic and objective, so it should actually verify the check digit rather than just the shape.

---

## Changes

* Add `_gstin_check_digit()` implementing the base-36 (`0-9A-Z`) GSTN algorithm: alternating 1/2 weighting, `(product // 36) + (product % 36)` accumulation, check = `(36 - (sum % 36)) % 36`.
* `verify_gstin_format()` now returns a distinct **checksum** error (separate from the **format** error) when the check digit is wrong.
* Correct the docstring to describe the real behavior.

---

## Tests

* `test_gstin_valid` now uses a real check-digit-valid GSTIN (`27AAPFU0939F1ZV`).
* Added `test_gstin_valid_format_wrong_checksum`: the old fixture `22AAAAA0000A1Z5` is format-valid but has an incorrect check digit (correct digit is `C`), so it now exercises the checksum-failure path.
* Full suite: `60 passed`.

---

## Scope

Structural + check-digit validation only. Live GSTN portal status lookup and the state-code (01–37) validity table are intentionally out of scope.

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GSTIN validation now includes checksum verification to ensure tax identification numbers are mathematically valid and properly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->