### PR TITLE
feat(gst): verify CGST/SGST/IGST split by place of supply

### DIFF
--- a/qwed_tax/jurisdictions/india/guards/gst_guard.py
+++ b/qwed_tax/jurisdictions/india/guards/gst_guard.py
@@ -63,6 +63,40 @@ class GSTGuard:
     # legs without letting a materially wrong split slip through.
     _SPLIT_TOLERANCE = Decimal("0.02")
 
+    _NUMERIC_FIELDS = (
+        "taxable_value",
+        "gst_rate",
+        "claimed_cgst",
+        "claimed_sgst",
+        "claimed_igst",
+    )
+
+    @staticmethod
+    def _parse_split_inputs(values: Dict[str, Any]) -> Dict[str, Decimal]:
+        """Parse all numeric inputs to Decimal, rejecting negatives. Raises ValueError."""
+        parsed: Dict[str, Decimal] = {}
+        for field in GSTGuard._NUMERIC_FIELDS:
+            amount = parse_decimal_input(values[field], field)
+            if amount < 0:
+                raise ValueError(f"{field} must be non-negative.")
+            parsed[field] = amount
+        return parsed
+
+    @staticmethod
+    def _expected_split(total_tax: Decimal, is_interstate: bool) -> Dict[str, Decimal]:
+        if is_interstate:
+            return {"cgst": Decimal("0"), "sgst": Decimal("0"), "igst": total_tax}
+        half = total_tax / Decimal("2")
+        return {"cgst": half, "sgst": half, "igst": Decimal("0")}
+
+    @staticmethod
+    def _wrong_type_note(is_interstate: bool, claimed: Dict[str, Decimal]) -> str:
+        if is_interstate and (claimed["cgst"] or claimed["sgst"]):
+            return "CGST/SGST claimed on an inter-state supply"
+        if not is_interstate and claimed["igst"]:
+            return "IGST claimed on an intra-state supply"
+        return ""
+
     def verify_gst_split(
         self,
         supplier_state: str,
@@ -83,7 +117,7 @@ class GSTGuard:
                 IGST = taxable_value * rate, and CGST/SGST must be 0.
 
         This verifies the *split*, not the rate itself (rate is an input).
-        Fails closed on missing states or non-finite numeric inputs.
+        Fails closed on missing states or non-finite/negative numeric inputs.
         """
         if not isinstance(supplier_state, str) or not supplier_state.strip():
             return {"verified": False, "error": "supplier_state is required."}
@@ -91,32 +125,29 @@ class GSTGuard:
             return {"verified": False, "error": "place_of_supply is required."}
 
         try:
-            value = parse_decimal_input(taxable_value, "taxable_value")
-            rate = parse_decimal_input(gst_rate, "gst_rate")
-            cgst = parse_decimal_input(claimed_cgst, "claimed_cgst")
-            sgst = parse_decimal_input(claimed_sgst, "claimed_sgst")
-            igst = parse_decimal_input(claimed_igst, "claimed_igst")
+            parsed = self._parse_split_inputs(
+                {
+                    "taxable_value": taxable_value,
+                    "gst_rate": gst_rate,
+                    "claimed_cgst": claimed_cgst,
+                    "claimed_sgst": claimed_sgst,
+                    "claimed_igst": claimed_igst,
+                }
+            )
         except ValueError as exc:
             return {"verified": False, "error": str(exc)}
 
-        if value < 0 or rate < 0:
-            return {
-                "verified": False,
-                "error": "taxable_value and gst_rate must be non-negative.",
-            }
+        total_tax = parsed["taxable_value"] * parsed["gst_rate"] / Decimal("100")
+        is_interstate = (
+            supplier_state.strip().upper() != place_of_supply.strip().upper()
+        )
 
-        total_tax = value * rate / Decimal("100")
-        is_interstate = supplier_state.strip().upper() != place_of_supply.strip().upper()
-
-        if is_interstate:
-            supply_type = "INTER_STATE"
-            expected = {"cgst": Decimal("0"), "sgst": Decimal("0"), "igst": total_tax}
-        else:
-            supply_type = "INTRA_STATE"
-            half = total_tax / Decimal("2")
-            expected = {"cgst": half, "sgst": half, "igst": Decimal("0")}
-
-        claimed = {"cgst": cgst, "sgst": sgst, "igst": igst}
+        expected = self._expected_split(total_tax, is_interstate)
+        claimed = {
+            "cgst": parsed["claimed_cgst"],
+            "sgst": parsed["claimed_sgst"],
+            "igst": parsed["claimed_igst"],
+        }
         mismatches = [
             leg
             for leg in ("cgst", "sgst", "igst")
@@ -124,28 +155,24 @@ class GSTGuard:
         ]
 
         result = {
-            "supply_type": supply_type,
+            "supply_type": "INTER_STATE" if is_interstate else "INTRA_STATE",
             "expected": {leg: decimal_text(amount) for leg, amount in expected.items()},
             "claimed": {leg: decimal_text(amount) for leg, amount in claimed.items()},
         }
 
         if mismatches:
-            wrong_type = (
-                "CGST/SGST claimed on an inter-state supply"
-                if is_interstate and (cgst or sgst)
-                else "IGST claimed on an intra-state supply"
-                if not is_interstate and igst
-                else None
-            )
             reason = (
-                f"GST split mismatch on {supply_type} supply ({', '.join(mismatches)})."
+                f"GST split mismatch on {result['supply_type']} supply "
+                f"({', '.join(mismatches)})."
             )
-            if wrong_type:
-                reason = f"{reason} {wrong_type}."
+            note = self._wrong_type_note(is_interstate, claimed)
+            if note:
+                reason = f"{reason} {note}."
             result["verified"] = False
             result["error"] = reason
             return result
 
         result["verified"] = True
         return result
+
 

--- a/qwed_tax/jurisdictions/india/guards/gst_guard.py
+++ b/qwed_tax/jurisdictions/india/guards/gst_guard.py
@@ -1,5 +1,10 @@
 from enum import Enum
+from typing import Any, Dict
+from decimal import Decimal
+
 from pydantic import BaseModel
+
+from qwed_tax.numeric import decimal_text, parse_decimal_input
 
 class EntityType(str, Enum):
     INDIVIDUAL = "INDIVIDUAL"
@@ -53,3 +58,94 @@ class GSTGuard:
             "is_rcm": is_rcm,
             "reason": reason
         }
+
+    # Two paise of tolerance absorbs benign half-rate rounding on the CGST/SGST
+    # legs without letting a materially wrong split slip through.
+    _SPLIT_TOLERANCE = Decimal("0.02")
+
+    def verify_gst_split(
+        self,
+        supplier_state: str,
+        place_of_supply: str,
+        taxable_value: Any,
+        gst_rate: Any,
+        claimed_cgst: Any,
+        claimed_sgst: Any,
+        claimed_igst: Any,
+    ) -> Dict[str, Any]:
+        """
+        Verify that a claimed CGST/SGST/IGST breakup matches the supply type.
+
+        Place-of-supply rule:
+          - Intra-state (supplier_state == place_of_supply):
+                CGST = SGST = taxable_value * rate / 2, and IGST must be 0.
+          - Inter-state (supplier_state != place_of_supply):
+                IGST = taxable_value * rate, and CGST/SGST must be 0.
+
+        This verifies the *split*, not the rate itself (rate is an input).
+        Fails closed on missing states or non-finite numeric inputs.
+        """
+        if not isinstance(supplier_state, str) or not supplier_state.strip():
+            return {"verified": False, "error": "supplier_state is required."}
+        if not isinstance(place_of_supply, str) or not place_of_supply.strip():
+            return {"verified": False, "error": "place_of_supply is required."}
+
+        try:
+            value = parse_decimal_input(taxable_value, "taxable_value")
+            rate = parse_decimal_input(gst_rate, "gst_rate")
+            cgst = parse_decimal_input(claimed_cgst, "claimed_cgst")
+            sgst = parse_decimal_input(claimed_sgst, "claimed_sgst")
+            igst = parse_decimal_input(claimed_igst, "claimed_igst")
+        except ValueError as exc:
+            return {"verified": False, "error": str(exc)}
+
+        if value < 0 or rate < 0:
+            return {
+                "verified": False,
+                "error": "taxable_value and gst_rate must be non-negative.",
+            }
+
+        total_tax = value * rate / Decimal("100")
+        is_interstate = supplier_state.strip().upper() != place_of_supply.strip().upper()
+
+        if is_interstate:
+            supply_type = "INTER_STATE"
+            expected = {"cgst": Decimal("0"), "sgst": Decimal("0"), "igst": total_tax}
+        else:
+            supply_type = "INTRA_STATE"
+            half = total_tax / Decimal("2")
+            expected = {"cgst": half, "sgst": half, "igst": Decimal("0")}
+
+        claimed = {"cgst": cgst, "sgst": sgst, "igst": igst}
+        mismatches = [
+            leg
+            for leg in ("cgst", "sgst", "igst")
+            if abs(claimed[leg] - expected[leg]) > self._SPLIT_TOLERANCE
+        ]
+
+        result = {
+            "supply_type": supply_type,
+            "expected": {leg: decimal_text(amount) for leg, amount in expected.items()},
+            "claimed": {leg: decimal_text(amount) for leg, amount in claimed.items()},
+        }
+
+        if mismatches:
+            wrong_type = (
+                "CGST/SGST claimed on an inter-state supply"
+                if is_interstate and (cgst or sgst)
+                else "IGST claimed on an intra-state supply"
+                if not is_interstate and igst
+                else None
+            )
+            reason = (
+                f"GST split mismatch on {supply_type} supply ({', '.join(mismatches)})."
+            )
+            if wrong_type:
+                reason = f"{reason} {wrong_type}."
+            result["verified"] = False
+            result["error"] = reason
+            return result
+
+        result["verified"] = True
+        return result
+

--- a/qwed_tax/jurisdictions/india/guards/gst_guard.py
+++ b/qwed_tax/jurisdictions/india/guards/gst_guard.py
@@ -97,6 +97,20 @@ class GSTGuard:
             return "IGST claimed on an intra-state supply"
         return ""
 
+    @classmethod
+    def _leg_mismatch(cls, claimed: Decimal, expected: Decimal) -> bool:
+        """
+        A leg mismatches when it deviates from the expected amount.
+
+        The rounding tolerance applies only to legs that carry tax (expected > 0),
+        where half-rate division can leave a sub-paise remainder. Legs that must
+        be exactly zero (the wrong tax type for the supply) get no tolerance, so
+        even a tiny wrong-type amount is rejected.
+        """
+        if expected == 0:
+            return claimed != 0
+        return abs(claimed - expected) > cls._SPLIT_TOLERANCE
+
     def verify_gst_split(
         self,
         supplier_state: str,
@@ -151,7 +165,7 @@ class GSTGuard:
         mismatches = [
             leg
             for leg in ("cgst", "sgst", "igst")
-            if abs(claimed[leg] - expected[leg]) > self._SPLIT_TOLERANCE
+            if self._leg_mismatch(claimed[leg], expected[leg])
         ]
 
         result = {

--- a/tests/test_gst_split.py
+++ b/tests/test_gst_split.py
@@ -1,0 +1,96 @@
+"""Tests for GST CGST/SGST/IGST split verification (place-of-supply based)."""
+
+from qwed_tax.jurisdictions.india.guards.gst_guard import GSTGuard
+
+
+class TestGSTSplit:
+    def setup_method(self):
+        self.guard = GSTGuard()
+
+    # ---- intra-state (CGST + SGST) ----
+
+    def test_intra_state_correct_split_passes(self):
+        # 18% of 1000 = 180 -> CGST 90 + SGST 90, IGST 0
+        res = self.guard.verify_gst_split(
+            "KA", "KA", 1000, 18, claimed_cgst=90, claimed_sgst=90, claimed_igst=0
+        )
+        assert res["verified"] is True
+        assert res["supply_type"] == "INTRA_STATE"
+
+    def test_intra_state_wrong_amount_blocks(self):
+        res = self.guard.verify_gst_split(
+            "KA", "KA", 1000, 18, claimed_cgst=100, claimed_sgst=80, claimed_igst=0
+        )
+        assert res["verified"] is False
+        assert "cgst" in res["error"] or "sgst" in res["error"]
+
+    def test_intra_state_igst_claimed_blocks_with_wrong_type(self):
+        # IGST used on an intra-state supply must be flagged.
+        res = self.guard.verify_gst_split(
+            "KA", "KA", 1000, 18, claimed_cgst=0, claimed_sgst=0, claimed_igst=180
+        )
+        assert res["verified"] is False
+        assert "IGST claimed on an intra-state supply" in res["error"]
+
+    # ---- inter-state (IGST) ----
+
+    def test_inter_state_correct_split_passes(self):
+        # 18% of 1000 = 180 -> IGST 180, CGST/SGST 0
+        res = self.guard.verify_gst_split(
+            "KA", "MH", 1000, 18, claimed_cgst=0, claimed_sgst=0, claimed_igst=180
+        )
+        assert res["verified"] is True
+        assert res["supply_type"] == "INTER_STATE"
+
+    def test_inter_state_cgst_sgst_claimed_blocks_with_wrong_type(self):
+        res = self.guard.verify_gst_split(
+            "KA", "MH", 1000, 18, claimed_cgst=90, claimed_sgst=90, claimed_igst=0
+        )
+        assert res["verified"] is False
+        assert "CGST/SGST claimed on an inter-state supply" in res["error"]
+
+    def test_state_codes_are_case_insensitive(self):
+        res = self.guard.verify_gst_split(
+            "ka", "KA", 1000, 18, claimed_cgst=90, claimed_sgst=90, claimed_igst=0
+        )
+        assert res["verified"] is True
+        assert res["supply_type"] == "INTRA_STATE"
+
+    # ---- tolerance ----
+
+    def test_half_rate_rounding_within_tolerance_passes(self):
+        # 5% of 999 = 49.95 -> each leg 24.975; claiming 24.98/24.97 is within 2 paise.
+        res = self.guard.verify_gst_split(
+            "KA", "KA", 999, 5, claimed_cgst="24.98", claimed_sgst="24.97", claimed_igst=0
+        )
+        assert res["verified"] is True
+
+    # ---- fail-closed input handling ----
+
+    def test_missing_supplier_state_blocks(self):
+        res = self.guard.verify_gst_split(
+            "", "KA", 1000, 18, claimed_cgst=90, claimed_sgst=90, claimed_igst=0
+        )
+        assert res["verified"] is False
+        assert "supplier_state" in res["error"]
+
+    def test_non_numeric_value_blocks(self):
+        res = self.guard.verify_gst_split(
+            "KA", "KA", "pending", 18, claimed_cgst=90, claimed_sgst=90, claimed_igst=0
+        )
+        assert res["verified"] is False
+        assert "numeric value" in res["error"]
+
+    def test_non_finite_value_blocks(self):
+        res = self.guard.verify_gst_split(
+            "KA", "KA", float("inf"), 18, claimed_cgst=90, claimed_sgst=90, claimed_igst=0
+        )
+        assert res["verified"] is False
+        assert "finite numeric value" in res["error"]
+
+    def test_negative_value_blocks(self):
+        res = self.guard.verify_gst_split(
+            "KA", "KA", -1000, 18, claimed_cgst=90, claimed_sgst=90, claimed_igst=0
+        )
+        assert res["verified"] is False
+        assert "non-negative" in res["error"]

--- a/tests/test_gst_split.py
+++ b/tests/test_gst_split.py
@@ -94,3 +94,19 @@ class TestGSTSplit:
         )
         assert res["verified"] is False
         assert "non-negative" in res["error"]
+
+    def test_negative_claimed_igst_blocks(self):
+        # A small negative leg within the tolerance window must still fail closed.
+        res = self.guard.verify_gst_split(
+            "KA", "KA", 1000, 18, claimed_cgst=90, claimed_sgst=90, claimed_igst="-0.01"
+        )
+        assert res["verified"] is False
+        assert "claimed_igst must be non-negative" in res["error"]
+
+    def test_negative_claimed_cgst_blocks(self):
+        res = self.guard.verify_gst_split(
+            "KA", "MH", 1000, 18, claimed_cgst="-0.01", claimed_sgst=0, claimed_igst=180
+        )
+        assert res["verified"] is False
+        assert "claimed_cgst must be non-negative" in res["error"]
+

--- a/tests/test_gst_split.py
+++ b/tests/test_gst_split.py
@@ -65,6 +65,22 @@ class TestGSTSplit:
         )
         assert res["verified"] is True
 
+    def test_tiny_wrong_type_amount_blocks_no_tolerance_on_zero_leg(self):
+        # IGST must be exactly 0 on an intra-state supply. A small amount under the
+        # rounding tolerance must NOT slip through, because zero legs get no tolerance.
+        res = self.guard.verify_gst_split(
+            "KA", "KA", 1000, 18, claimed_cgst=90, claimed_sgst=90, claimed_igst="0.01"
+        )
+        assert res["verified"] is False
+        assert "IGST claimed on an intra-state supply" in res["error"]
+
+    def test_tiny_cgst_on_inter_state_blocks(self):
+        res = self.guard.verify_gst_split(
+            "KA", "MH", 1000, 18, claimed_cgst="0.01", claimed_sgst=0, claimed_igst=180
+        )
+        assert res["verified"] is False
+        assert "CGST/SGST claimed on an inter-state supply" in res["error"]
+
     # ---- fail-closed input handling ----
 
     def test_missing_supplier_state_blocks(self):


### PR DESCRIPTION
## What

Adds `GSTGuard.verify_gst_split(...)` to verify that a claimed CGST/SGST/IGST breakup is consistent with the supply type, based on place of supply.

---

## Why

There was previously no CGST/SGST/IGST logic in the codebase. Choosing the wrong tax type (CGST+SGST vs IGST) is one of the most common GST errors and a frequent audit flag — and it's fully deterministic, so it's a natural fit for a verification guard.

---

## Behavior

**Place-of-Supply Rule:**
* **Intra-state** (`supplier_state == place_of_supply`): `CGST = SGST = taxable_value * rate / 2`, and `IGST` must be `0`.
* **Inter-state** (`supplier_state != place_of_supply`): `IGST = taxable_value * rate`, and `CGST`/`SGST` must be `0`.

**Implementation Details:**
* Verifies the **split**, not the rate (rate is an input).
* Exact `Decimal` arithmetic (reuses `qwed_tax/numeric.py`), with a 2-paise tolerance to absorb benign half-rate rounding on the CGST/SGST legs.
* Fails closed on missing states and non-finite / negative numeric inputs.
* Flags wrong-tax-type usage explicitly (e.g., *"IGST claimed on an intra-state supply"*).
* State codes compared case-insensitively.

**Output Shape:**
```python
{
  "verified": bool,
  "supply_type": "INTRA_STATE" | "INTER_STATE",
  "expected": {"cgst": "...", "sgst": "...", "igst": "..."},
  "claimed":  {"cgst": "...", "sgst": "...", "igst": "..."},
  "error": "<reason>"   # only when verified is False
}

```

---

## Tests

* New `tests/test_gst_split.py` — 11 cases covering: correct intra/inter splits, wrong amounts, wrong tax type both directions, case-insensitive states, rounding tolerance, and fail-closed input handling.
* Full suite: `71 passed`.

---

## Scope

* Place-of-supply special cases (exports, SEZ, OIDAR, imports, bill-to/ship-to) and UTGST are intentionally out of scope.
* HSN-driven rate lookup is also out of scope — `gst_rate` is an input here.

Closes #30