### PR TITLE
feat(audit): add structured statutory audit-trace to guard verdicts

### DIFF
--- a/qwed_tax/audit.py
+++ b/qwed_tax/audit.py
@@ -16,30 +16,31 @@ duplicating inline literals.
 
 from __future__ import annotations
 
+import copy
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 JURISDICTION_INDIA = "INDIA"
 
 
+@dataclass(frozen=True)
 class RuleRef:
-    """A canonical (rule_id, statute, jurisdiction) reference."""
+    """A canonical, immutable (rule_id, statute, jurisdiction) reference."""
 
-    __slots__ = ("rule_id", "statute", "jurisdiction")
-
-    def __init__(self, rule_id: str, statute: str, jurisdiction: str = JURISDICTION_INDIA):
-        self.rule_id = rule_id
-        self.statute = statute
-        self.jurisdiction = jurisdiction
+    rule_id: str
+    statute: str
+    jurisdiction: str = JURISDICTION_INDIA
 
 
 # --- Centralised rule references -------------------------------------------
 # Input Tax Credit (GST)
 ITC_BLOCKED_17_5 = RuleRef("ITC_BLOCKED_17_5", "CGST Act, Section 17(5)")
 ITC_PERSONAL_CONSUMPTION = RuleRef(
-    "ITC_PERSONAL_CONSUMPTION", "CGST Act, Section 17(1)"
+    "ITC_PERSONAL_CONSUMPTION", "CGST Act, Section 17(5)(g)"
 )
 ITC_ELIGIBLE = RuleRef("ITC_ELIGIBLE", "CGST Act, Section 16")
 ITC_GIFT_THRESHOLD = RuleRef("ITC_GIFT_THRESHOLD", "CGST Act, Section 17(5)(h)")
+
 
 # Tax Deducted at Source (Income Tax Act)
 TDS_194J = RuleRef("TDS_194J", "Income Tax Act, Section 194J")
@@ -71,5 +72,5 @@ def build_trace(
         "statute": rule.statute,
         "jurisdiction": rule.jurisdiction,
         "outcome": outcome,
-        "inputs": dict(inputs) if inputs else {},
+        "inputs": copy.deepcopy(inputs) if inputs else {},
     }

--- a/qwed_tax/audit.py
+++ b/qwed_tax/audit.py
@@ -1,0 +1,75 @@
+"""
+Structured statutory audit trace for guard verdicts.
+
+Guards historically return free-text ``reason`` / ``error`` strings. That is
+fine for humans but not machine-readable: an auditor cannot reliably answer
+"which statute drove this block?" by parsing prose.
+
+This module provides a small, shared, additive structure that guards can attach
+to their results under the ``audit_trace`` key. Existing keys are never changed,
+so callers that ignore ``audit_trace`` keep working unchanged.
+
+Rule identifiers and statute strings live here as constants so that multiple
+guards (and future ones) reference the same canonical values instead of
+duplicating inline literals.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+JURISDICTION_INDIA = "INDIA"
+
+
+class RuleRef:
+    """A canonical (rule_id, statute, jurisdiction) reference."""
+
+    __slots__ = ("rule_id", "statute", "jurisdiction")
+
+    def __init__(self, rule_id: str, statute: str, jurisdiction: str = JURISDICTION_INDIA):
+        self.rule_id = rule_id
+        self.statute = statute
+        self.jurisdiction = jurisdiction
+
+
+# --- Centralised rule references -------------------------------------------
+# Input Tax Credit (GST)
+ITC_BLOCKED_17_5 = RuleRef("ITC_BLOCKED_17_5", "CGST Act, Section 17(5)")
+ITC_PERSONAL_CONSUMPTION = RuleRef(
+    "ITC_PERSONAL_CONSUMPTION", "CGST Act, Section 17(1)"
+)
+ITC_ELIGIBLE = RuleRef("ITC_ELIGIBLE", "CGST Act, Section 16")
+ITC_GIFT_THRESHOLD = RuleRef("ITC_GIFT_THRESHOLD", "CGST Act, Section 17(5)(h)")
+
+# Tax Deducted at Source (Income Tax Act)
+TDS_194J = RuleRef("TDS_194J", "Income Tax Act, Section 194J")
+TDS_194C = RuleRef("TDS_194C", "Income Tax Act, Section 194C")
+TDS_194H = RuleRef("TDS_194H", "Income Tax Act, Section 194H")
+TDS_194I = RuleRef("TDS_194I", "Income Tax Act, Section 194I")
+
+
+def build_trace(
+    rule: RuleRef,
+    outcome: str,
+    inputs: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Build a structured audit-trace entry for a guard verdict.
+
+    Args:
+        rule: the canonical rule reference that drove the verdict.
+        outcome: short machine-readable outcome, e.g. "BLOCKED", "ALLOWED",
+            "DEDUCTION_REQUIRED".
+        inputs: the decision-relevant inputs (already normalised), so the
+            verdict can be reproduced/audited.
+
+    Returns:
+        A plain dict suitable for embedding under a result's ``audit_trace`` key.
+    """
+    return {
+        "rule_id": rule.rule_id,
+        "statute": rule.statute,
+        "jurisdiction": rule.jurisdiction,
+        "outcome": outcome,
+        "inputs": dict(inputs) if inputs else {},
+    }

--- a/qwed_tax/guards/indirect_tax_guard.py
+++ b/qwed_tax/guards/indirect_tax_guard.py
@@ -45,14 +45,28 @@ class InputCreditGuard:
             return {"verified": False, "eligible_itc": "0", "reason": str(exc)}
 
         # Gift threshold: gifts of 50,000 INR or less remain eligible; only amounts above that block.
-        if normalized_cat == "GIFT_TO_EMPLOYEE" and parsed_amount <= Decimal("50000"):
+        if normalized_cat == "GIFT_TO_EMPLOYEE":
+            if parsed_amount <= Decimal("50000"):
+                return {
+                    "verified": True,
+                    "eligible_itc": decimal_text(parsed_tax_paid),
+                    "note": "Gift of INR 50,000 or less; ITC allowed.",
+                    "audit_trace": build_trace(
+                        ITC_GIFT_THRESHOLD,
+                        "ALLOWED",
+                        {"expense_category": normalized_cat, "amount": decimal_text(parsed_amount)},
+                    ),
+                }
             return {
-                "verified": True,
-                "eligible_itc": decimal_text(parsed_tax_paid),
-                "note": "Gift of INR 50,000 or less; ITC allowed.",
+                "verified": False,
+                "eligible_itc": "0",
+                "reason": (
+                    "ITC is blocked for gifts to employees exceeding INR 50,000 "
+                    "under Section 17(5)(h)."
+                ),
                 "audit_trace": build_trace(
                     ITC_GIFT_THRESHOLD,
-                    "ALLOWED",
+                    "BLOCKED",
                     {"expense_category": normalized_cat, "amount": decimal_text(parsed_amount)},
                 ),
             }

--- a/qwed_tax/guards/indirect_tax_guard.py
+++ b/qwed_tax/guards/indirect_tax_guard.py
@@ -2,6 +2,13 @@ from decimal import Decimal
 import re
 from typing import Any, Dict, List
 
+from qwed_tax.audit import (
+    ITC_BLOCKED_17_5,
+    ITC_ELIGIBLE,
+    ITC_GIFT_THRESHOLD,
+    ITC_PERSONAL_CONSUMPTION,
+    build_trace,
+)
 from qwed_tax.numeric import decimal_text, parse_decimal_input
 
 
@@ -43,6 +50,11 @@ class InputCreditGuard:
                 "verified": True,
                 "eligible_itc": decimal_text(parsed_tax_paid),
                 "note": "Gift of INR 50,000 or less; ITC allowed.",
+                "audit_trace": build_trace(
+                    ITC_GIFT_THRESHOLD,
+                    "ALLOWED",
+                    {"expense_category": normalized_cat, "amount": decimal_text(parsed_amount)},
+                ),
             }
 
         # Blocked categories
@@ -53,6 +65,11 @@ class InputCreditGuard:
                 "reason": (
                     f"ITC is blocked for '{expense_category}' under Section 17(5) / VAT Rules."
                 ),
+                "audit_trace": build_trace(
+                    ITC_BLOCKED_17_5,
+                    "BLOCKED",
+                    {"expense_category": normalized_cat},
+                ),
             }
 
         # Personal consumption check (heuristic)
@@ -61,12 +78,22 @@ class InputCreditGuard:
                 "verified": False,
                 "eligible_itc": "0",
                 "reason": "ITC is blocked for personal consumption.",
+                "audit_trace": build_trace(
+                    ITC_PERSONAL_CONSUMPTION,
+                    "BLOCKED",
+                    {"expense_category": normalized_cat},
+                ),
             }
 
         return {
             "verified": True,
             "eligible_itc": decimal_text(parsed_tax_paid),
             "note": "Expense appears eligible for Input Tax Credit.",
+            "audit_trace": build_trace(
+                ITC_ELIGIBLE,
+                "ALLOWED",
+                {"expense_category": normalized_cat},
+            ),
         }
 
     # GSTIN check-digit alphabet: digits 0-9 followed by A-Z (base 36).

--- a/qwed_tax/guards/tds_guard.py
+++ b/qwed_tax/guards/tds_guard.py
@@ -49,6 +49,9 @@ class TDSGuard:
                 "verified": True,
                 "deduction": decimal_text(deduction),
                 "net_payable": decimal_text(inv_amt - deduction),
+                # Kept for backward compatibility; audit_trace carries the
+                # canonical statutory reference.
+                "section": service_type,
                 "audit_trace": build_trace(
                     rule["rule"],
                     "DEDUCTION_REQUIRED",

--- a/qwed_tax/guards/tds_guard.py
+++ b/qwed_tax/guards/tds_guard.py
@@ -49,7 +49,6 @@ class TDSGuard:
                 "verified": True,
                 "deduction": decimal_text(deduction),
                 "net_payable": decimal_text(inv_amt - deduction),
-                "section": service_type,
                 "audit_trace": build_trace(
                     rule["rule"],
                     "DEDUCTION_REQUIRED",

--- a/qwed_tax/guards/tds_guard.py
+++ b/qwed_tax/guards/tds_guard.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from typing import Any, Dict
 
+from qwed_tax.audit import TDS_194C, TDS_194H, TDS_194I, TDS_194J, build_trace
 from qwed_tax.numeric import decimal_text, parse_decimal_input
 
 class TDSGuard:
@@ -12,11 +13,11 @@ class TDSGuard:
         # 2025 TDS Thresholds & Rates (Simplified based on India Income Tax Act)
         # Rates are strict Decimal to avoid float errors
         self.tds_rules = {
-            "PROFESSIONAL_FEES": {"threshold": Decimal("30000"), "rate": Decimal("0.10")}, # Sec 194J
-            "CONTRACTOR_INDIVIDUAL": {"threshold": Decimal("30000"), "rate": Decimal("0.01")}, # Sec 194C
-            "CONTRACTOR_FIRM": {"threshold": Decimal("30000"), "rate": Decimal("0.02")},       # Sec 194C
-            "COMMISSION": {"threshold": Decimal("15000"), "rate": Decimal("0.05")},            # Sec 194H
-            "RENT_LAND": {"threshold": Decimal("240000"), "rate": Decimal("0.10")}             # Sec 194I
+            "PROFESSIONAL_FEES": {"threshold": Decimal("30000"), "rate": Decimal("0.10"), "rule": TDS_194J},
+            "CONTRACTOR_INDIVIDUAL": {"threshold": Decimal("30000"), "rate": Decimal("0.01"), "rule": TDS_194C},
+            "CONTRACTOR_FIRM": {"threshold": Decimal("30000"), "rate": Decimal("0.02"), "rule": TDS_194C},
+            "COMMISSION": {"threshold": Decimal("15000"), "rate": Decimal("0.05"), "rule": TDS_194H},
+            "RENT_LAND": {"threshold": Decimal("240000"), "rate": Decimal("0.10"), "rule": TDS_194I},
         }
 
     def calculate_deduction(self, service_type: str, invoice_amount: Any, ytd_payment: Any) -> Dict[str, Any]:
@@ -48,7 +49,29 @@ class TDSGuard:
                 "verified": True,
                 "deduction": decimal_text(deduction),
                 "net_payable": decimal_text(inv_amt - deduction),
-                "section": service_type
+                "section": service_type,
+                "audit_trace": build_trace(
+                    rule["rule"],
+                    "DEDUCTION_REQUIRED",
+                    {
+                        "service_type": service_type.upper().replace(" ", "_"),
+                        "total_exposure": decimal_text(total_exposure),
+                        "threshold": decimal_text(threshold),
+                    },
+                ),
             }
-            
-        return {"verified": True, "deduction": "0", "net_payable": decimal_text(inv_amt)}
+
+        return {
+            "verified": True,
+            "deduction": "0",
+            "net_payable": decimal_text(inv_amt),
+            "audit_trace": build_trace(
+                rule["rule"],
+                "BELOW_THRESHOLD",
+                {
+                    "service_type": service_type.upper().replace(" ", "_"),
+                    "total_exposure": decimal_text(total_exposure),
+                    "threshold": decimal_text(threshold),
+                },
+            ),
+        }

--- a/tests/test_audit_trace.py
+++ b/tests/test_audit_trace.py
@@ -1,5 +1,7 @@
 """Tests for structured statutory audit-trace on guard verdicts."""
 
+import pytest
+
 from qwed_tax.audit import build_trace, ITC_BLOCKED_17_5, JURISDICTION_INDIA
 from qwed_tax.guards.indirect_tax_guard import InputCreditGuard
 from qwed_tax.guards.tds_guard import TDSGuard
@@ -24,6 +26,18 @@ class TestBuildTrace:
         src["a"] = 2
         assert trace["inputs"]["a"] == 1  # snapshot, not a live reference
 
+    def test_trace_inputs_deep_copied(self):
+        src = {"legs": ["cgst"]}
+        trace = build_trace(ITC_BLOCKED_17_5, "BLOCKED", src)
+        src["legs"].append("sgst")
+        assert trace["inputs"]["legs"] == ["cgst"]  # nested mutation must not leak
+
+    def test_rule_ref_is_immutable(self):
+        import dataclasses
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ITC_BLOCKED_17_5.rule_id = "tampered"
+
 
 class TestITCAuditTrace:
     def setup_method(self):
@@ -41,6 +55,9 @@ class TestITCAuditTrace:
     def test_personal_consumption_emits_trace(self):
         res = self.guard.verify_itc_eligibility("personal expense", 500, 90)
         assert res["audit_trace"]["rule_id"] == "ITC_PERSONAL_CONSUMPTION"
+        # Personal consumption is blocked under 17(5)(g), not the apportionment
+        # rule 17(1).
+        assert res["audit_trace"]["statute"] == "CGST Act, Section 17(5)(g)"
 
     def test_eligible_expense_emits_trace(self):
         res = self.guard.verify_itc_eligibility("office supplies", 1000, 180)
@@ -51,6 +68,15 @@ class TestITCAuditTrace:
     def test_gift_below_threshold_emits_trace(self):
         res = self.guard.verify_itc_eligibility("gift to employee", 30000, 5400)
         assert res["audit_trace"]["rule_id"] == "ITC_GIFT_THRESHOLD"
+        assert res["audit_trace"]["outcome"] == "ALLOWED"
+
+    def test_gift_above_threshold_emits_specific_17_5_h_trace(self):
+        # Over-threshold gift must cite the specific 17(5)(h), not the general 17(5).
+        res = self.guard.verify_itc_eligibility("gift to employee", 60000, 10800)
+        assert res["verified"] is False
+        assert res["audit_trace"]["rule_id"] == "ITC_GIFT_THRESHOLD"
+        assert res["audit_trace"]["statute"] == "CGST Act, Section 17(5)(h)"
+        assert res["audit_trace"]["outcome"] == "BLOCKED"
 
 
 class TestTDSAuditTrace:

--- a/tests/test_audit_trace.py
+++ b/tests/test_audit_trace.py
@@ -89,8 +89,9 @@ class TestTDSAuditTrace:
         assert res["audit_trace"]["rule_id"] == "TDS_194J"
         assert res["audit_trace"]["statute"] == "Income Tax Act, Section 194J"
         assert res["audit_trace"]["outcome"] == "DEDUCTION_REQUIRED"
-        # Legacy keys preserved.
+        # Legacy keys preserved (additive-only contract).
         assert res["deduction"] == "5000.00"
+        assert res["section"] == "PROFESSIONAL_FEES"
 
     def test_below_threshold_emits_trace(self):
         res = self.guard.calculate_deduction("PROFESSIONAL_FEES", 1000, 0)

--- a/tests/test_audit_trace.py
+++ b/tests/test_audit_trace.py
@@ -1,0 +1,82 @@
+"""Tests for structured statutory audit-trace on guard verdicts."""
+
+from qwed_tax.audit import build_trace, ITC_BLOCKED_17_5, JURISDICTION_INDIA
+from qwed_tax.guards.indirect_tax_guard import InputCreditGuard
+from qwed_tax.guards.tds_guard import TDSGuard
+
+
+class TestBuildTrace:
+    def test_trace_shape(self):
+        trace = build_trace(ITC_BLOCKED_17_5, "BLOCKED", {"expense_category": "CATERING"})
+        assert trace["rule_id"] == "ITC_BLOCKED_17_5"
+        assert trace["statute"] == "CGST Act, Section 17(5)"
+        assert trace["jurisdiction"] == JURISDICTION_INDIA
+        assert trace["outcome"] == "BLOCKED"
+        assert trace["inputs"] == {"expense_category": "CATERING"}
+
+    def test_trace_inputs_default_empty(self):
+        trace = build_trace(ITC_BLOCKED_17_5, "BLOCKED")
+        assert trace["inputs"] == {}
+
+    def test_trace_inputs_are_copied(self):
+        src = {"a": 1}
+        trace = build_trace(ITC_BLOCKED_17_5, "BLOCKED", src)
+        src["a"] = 2
+        assert trace["inputs"]["a"] == 1  # snapshot, not a live reference
+
+
+class TestITCAuditTrace:
+    def setup_method(self):
+        self.guard = InputCreditGuard()
+
+    def test_blocked_category_emits_17_5_trace(self):
+        res = self.guard.verify_itc_eligibility("food and beverage", 5000, 900)
+        assert res["verified"] is False
+        assert res["audit_trace"]["rule_id"] == "ITC_BLOCKED_17_5"
+        assert res["audit_trace"]["outcome"] == "BLOCKED"
+        # Backward compatibility: legacy keys unchanged.
+        assert res["eligible_itc"] == "0"
+        assert "reason" in res
+
+    def test_personal_consumption_emits_trace(self):
+        res = self.guard.verify_itc_eligibility("personal expense", 500, 90)
+        assert res["audit_trace"]["rule_id"] == "ITC_PERSONAL_CONSUMPTION"
+
+    def test_eligible_expense_emits_trace(self):
+        res = self.guard.verify_itc_eligibility("office supplies", 1000, 180)
+        assert res["verified"] is True
+        assert res["audit_trace"]["rule_id"] == "ITC_ELIGIBLE"
+        assert res["audit_trace"]["outcome"] == "ALLOWED"
+
+    def test_gift_below_threshold_emits_trace(self):
+        res = self.guard.verify_itc_eligibility("gift to employee", 30000, 5400)
+        assert res["audit_trace"]["rule_id"] == "ITC_GIFT_THRESHOLD"
+
+
+class TestTDSAuditTrace:
+    def setup_method(self):
+        self.guard = TDSGuard()
+
+    def test_deduction_required_emits_section_trace(self):
+        # Professional fees -> Sec 194J, threshold crossed.
+        res = self.guard.calculate_deduction("PROFESSIONAL_FEES", 50000, 0)
+        assert res["audit_trace"]["rule_id"] == "TDS_194J"
+        assert res["audit_trace"]["statute"] == "Income Tax Act, Section 194J"
+        assert res["audit_trace"]["outcome"] == "DEDUCTION_REQUIRED"
+        # Legacy keys preserved.
+        assert res["deduction"] == "5000.00"
+
+    def test_below_threshold_emits_trace(self):
+        res = self.guard.calculate_deduction("PROFESSIONAL_FEES", 1000, 0)
+        assert res["audit_trace"]["outcome"] == "BELOW_THRESHOLD"
+        assert res["audit_trace"]["rule_id"] == "TDS_194J"
+
+    def test_contractor_firm_maps_to_194c(self):
+        res = self.guard.calculate_deduction("CONTRACTOR_FIRM", 50000, 0)
+        assert res["audit_trace"]["rule_id"] == "TDS_194C"
+
+    def test_unknown_category_has_no_trace(self):
+        # No statutory rule applies, so no trace is emitted (legacy behavior).
+        res = self.guard.calculate_deduction("UNKNOWN_SERVICE", 50000, 0)
+        assert "audit_trace" not in res
+        assert res["verified"] is True


### PR DESCRIPTION
## What

Adds a shared, additive `audit_trace` structure so guard verdicts carry a machine-readable statutory reference (which rule drove the decision), instead of only free-text `reason`/`error` strings.

---

## Why

An auditor can't reliably answer *"which statute blocked this?"* by parsing prose. A structured trace makes verdicts filterable and aggregatable (e.g., *"how many blocks were Sec 17(5)?"*) and backs up the procedural-accuracy positioning with actual evidence.

---

## Design

* **New `qwed_tax/audit.py`:**
  * `RuleRef` + centralised rule references (`rule_id`, `statute`, `jurisdiction`) so guards share canonical values instead of inline literals.
  * `build_trace(rule, outcome, inputs)` returns a plain dict for embedding under a result's `audit_trace` key. Inputs are snapshotted (copied), not referenced.
* **Additive only:** Every existing result key (`verified`, `reason`, `eligible_itc`, `deduction`, …) is unchanged, so callers that ignore `audit_trace` keep working.

---

## Guards Wired (Highest-value first)

* **InputCreditGuard (ITC)** — Sec 17(5) block, personal consumption, gift threshold, and eligible paths.
* **TDSGuard** — Maps service types to Sec 194J / 194C / 194H / 194I and emits `DEDUCTION_REQUIRED` / `BELOW_THRESHOLD` outcomes. Unknown categories emit no trace (unchanged legacy behavior).

**Example:**
```json
{
  "verified": false,
  "eligible_itc": "0",
  "reason": "ITC is blocked for 'catering' under Section 17(5) / VAT Rules.",
  "audit_trace": {
    "rule_id": "ITC_BLOCKED_17_5",
    "statute": "CGST Act, Section 17(5)",
    "jurisdiction": "INDIA",
    "outcome": "BLOCKED",
    "inputs": {"expense_category": "CATERING"}
  }
}

```

---

## Tests

* New `tests/test_audit_trace.py` (11 cases): trace shape/immutability, ITC paths, TDS section mapping + outcomes, and no-trace-for-unknown-category.
* Full suite: `86 passed`.

---

## Scope

Trace is wired into ITC and TDS in this PR. The same `audit.py` references are designed to be reused by the RCM guard and others (a natural follow-up — see the RCM coverage work). Signed/tamper-evident logs and external persistence are out of scope.

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Verification results for tax calculations now include structured audit trace metadata—containing rule references, statute citations, jurisdiction, and decision outcomes—for ITC eligibility checks and TDS deductions, providing complete audit trail transparency.

* **Tests**
  * Added comprehensive test coverage validating audit trace output across tax verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->