### PR TITLE
fix: fail-closed on unknown/unmodeled tax rules (#16)

### DIFF
--- a/qwed_tax/address_guard.py
+++ b/qwed_tax/address_guard.py
@@ -24,7 +24,7 @@ class AddressGuard:
         }
         
         if state not in valid_prefixes:
-            return {"verified": True, "message": "State not in validation database yet (Assumed Valid)"}
+            return {"verified": False, "message": f"State {state.value} not in validation database. Address cannot be auto-verified — manual review required."}
             
         if zip_prefix in valid_prefixes[state]:
             return {"verified": True, "message": "✅ Zip code matches State."}

--- a/qwed_tax/guards/capital_gains_guard.py
+++ b/qwed_tax/guards/capital_gains_guard.py
@@ -52,7 +52,7 @@ class CapitalGainsGuard:
         expected = rates.get(key)
         
         if not expected:
-             return {"verified": True, "note": f"No hard constraint for {key}"}
+             return {"verified": False, "error": f"No statutory rate configured for {key}. Cannot verify claimed rate."}
 
         if expected == "SLAB":
             # If rate is variable (slab), we can't do simple string match. 

--- a/qwed_tax/guards/indirect_tax_guard.py
+++ b/qwed_tax/guards/indirect_tax_guard.py
@@ -103,10 +103,11 @@ class InputCreditGuard:
             "verified": True,
             "eligible_itc": decimal_text(parsed_tax_paid),
             "note": "Expense appears eligible for Input Tax Credit.",
+            "unverified_category": True,
             "audit_trace": build_trace(
                 ITC_ELIGIBLE,
                 "ALLOWED",
-                {"expense_category": normalized_cat},
+                {"expense_category": normalized_cat, "category_match": "default_allow"},
             ),
         }
 

--- a/qwed_tax/guards/nexus_guard.py
+++ b/qwed_tax/guards/nexus_guard.py
@@ -28,7 +28,10 @@ class NexusGuard:
         """
         state_code = state.upper()
         if state_code not in self.state_thresholds:
-            return {"verified": True, "note": f"State {state_code} not in automated high-risk list"}
+            return {
+                "verified": False,
+                "error": f"State {state_code} not in configured nexus threshold table. Cannot verify nexus liability — block pending rule configuration.",
+            }
 
         try:
             parsed_sales = parse_decimal_input(ytd_sales, "ytd_sales")

--- a/qwed_tax/guards/tds_guard.py
+++ b/qwed_tax/guards/tds_guard.py
@@ -26,7 +26,11 @@ class TDSGuard:
         """
         rule = self.tds_rules.get(service_type.upper().replace(" ", "_"))
         if not rule:
-            return {"verified": True, "deduction": "0", "note": "No TDS rule found for category"}
+            return {
+                "verified": False,
+                "deduction": "0",
+                "error": f"No TDS rule configured for service type '{service_type}'. Cannot verify — block pending rule configuration.",
+            }
 
         try:
             inv_amt = parse_decimal_input(invoice_amount, "invoice_amount")

--- a/qwed_tax/guards/tds_guard.py
+++ b/qwed_tax/guards/tds_guard.py
@@ -28,7 +28,6 @@ class TDSGuard:
         if not rule:
             return {
                 "verified": False,
-                "deduction": "0",
                 "error": f"No TDS rule configured for service type '{service_type}'. Cannot verify — block pending rule configuration.",
             }
 

--- a/qwed_tax/jurisdictions/us/form1099_guard.py
+++ b/qwed_tax/jurisdictions/us/form1099_guard.py
@@ -26,7 +26,7 @@ class Form1099Guard:
         rule = _FILING_RULES.get(ptype)
         if rule is None:
             return {
-                "filing_required": None,
+                "filing_required": "UNVERIFIABLE",
                 "form": None,
                 "reason": f"No filing rule configured for payment type '{ptype}'. Cannot verify filing requirement — manual determination required.",
             }

--- a/qwed_tax/jurisdictions/us/form1099_guard.py
+++ b/qwed_tax/jurisdictions/us/form1099_guard.py
@@ -26,9 +26,9 @@ class Form1099Guard:
         rule = _FILING_RULES.get(ptype)
         if rule is None:
             return {
-                "filing_required": False,
+                "filing_required": None,
                 "form": None,
-                "reason": f"No filing rule defined for payment type '{ptype}'."
+                "reason": f"No filing rule configured for payment type '{ptype}'. Cannot verify filing requirement — manual determination required.",
             }
 
         form_name, threshold = rule

--- a/tests/test_audit_trace.py
+++ b/tests/test_audit_trace.py
@@ -103,7 +103,7 @@ class TestTDSAuditTrace:
         assert res["audit_trace"]["rule_id"] == "TDS_194C"
 
     def test_unknown_category_has_no_trace(self):
-        # No statutory rule applies, so no trace is emitted (legacy behavior).
+        # Unknown service type must fail closed (Issue #16) — no longer returns verified=True.
         res = self.guard.calculate_deduction("UNKNOWN_SERVICE", 50000, 0)
+        assert res["verified"] is False
         assert "audit_trace" not in res
-        assert res["verified"] is True

--- a/tests/test_guards_coverage.py
+++ b/tests/test_guards_coverage.py
@@ -311,6 +311,19 @@ class TestForm1099Guard:
         assert res["filing_required"] is True
         assert res["form"] == "1099-MISC"
 
+    def test_healthcare_unmodeled_filing_required_is_unverifiable(self):
+        """HEALTHCARE is a valid enum value with no filing rule — must not default to False."""
+        payment = ContractorPayment(
+            contractor_id="C007",
+            payment_type=PaymentType.HEALTHCARE,
+            amount=Decimal("5000.00"),
+            calendar_year=2024,
+        )
+        res = self.guard.verify_filing_requirement(payment)
+        assert res["filing_required"] == "UNVERIFIABLE"
+        assert res["form"] is None
+        assert "manual determination required" in res["reason"]
+
 
 # ------------------------------------------------------------------
 # TaxPreFlight - fail-closed action orchestration

--- a/tests/test_guards_coverage.py
+++ b/tests/test_guards_coverage.py
@@ -631,3 +631,67 @@ class TestTaxPreFlightAudit:
         assert report["allowed"] is False
         assert report["checks_run"] == ["worker_classification"]
         assert "Misclassification Risk" in report["blocks"][0]
+
+
+# ------------------------------------------------------------------
+# Issue #16: Fail-closed on unknown/unmodeled tax rules
+# ------------------------------------------------------------------
+
+
+class TestIssue16FailClosedUnknownRules:
+    """Each guard must fail closed when it encounters an unknown rule, category, state, or type."""
+
+    def test_tds_unknown_service_type_blocks(self):
+        """TDSGuard must not return verified=True for unmapped service types."""
+        guard = TDSGuard()
+        res = guard.calculate_deduction("UNKNOWN_SERVICE", 50000, 0)
+        assert res["verified"] is False
+        assert "No TDS rule configured" in res["error"]
+        assert "deduction" not in res
+
+    def test_capital_gains_unknown_asset_type_blocks(self):
+        """CapitalGainsGuard must not return verified=True for unmapped asset/term combos."""
+        from qwed_tax.guards.capital_gains_guard import CapitalGainsGuard
+        guard = CapitalGainsGuard()
+        res = guard.verify_tax_rate("gold", "LTCG", "10%")
+        assert res["verified"] is False
+        assert "No statutory rate configured" in res["error"]
+
+    def test_capital_gains_known_rate_still_passes(self):
+        """Known asset/term must still verify correctly — no regression."""
+        from qwed_tax.guards.capital_gains_guard import CapitalGainsGuard
+        guard = CapitalGainsGuard()
+        res = guard.verify_tax_rate("equity", "LTCG", "12.5%")
+        assert res["verified"] is True
+
+    def test_nexus_unknown_state_blocks(self):
+        """NexusGuard must not return verified=True for unlisted states."""
+        guard = NexusGuard()
+        res = guard.check_nexus_liability("WA", 900000, 500, "no_tax")
+        assert res["verified"] is False
+        assert "not in configured nexus threshold table" in res["error"]
+
+    def test_nexus_known_state_still_passes(self):
+        """Known state with no nexus violation must still pass — no regression."""
+        guard = NexusGuard()
+        res = guard.check_nexus_liability("CA", 100, 0, "no_tax")
+        assert res["verified"] is True
+
+    def test_address_unknown_state_blocks(self):
+        """AddressGuard must not return verified=True for unlisted states."""
+        from qwed_tax.address_guard import AddressGuard
+        from qwed_tax.models import Address, State
+        guard = AddressGuard()
+        addr = Address(street="123 Main St", city="Baltimore", state=State.MD, zip_code="21201")
+        res = guard.verify_address(addr)
+        assert res["verified"] is False
+        assert "manual review required" in res["message"]
+
+    def test_address_known_state_still_passes(self):
+        """Known state with matching zip prefix must still pass — no regression."""
+        from qwed_tax.address_guard import AddressGuard
+        from qwed_tax.models import Address, State
+        guard = AddressGuard()
+        addr = Address(street="123 Main St", city="New York", state=State.NY, zip_code="10001")
+        res = guard.verify_address(addr)
+        assert res["verified"] is True


### PR DESCRIPTION
## Summary

Fixes #16 — replaces all "unknown rule → `verified=True`" fail-open behavior with fail-closed outcomes across 6 guards.

## Changes

| Guard | File | Before | After |
|-------|------|--------|-------|
| TDSGuard | `guards/tds_guard.py:27-29` | Unknown service → `verified=True, deduction="0"` | `verified=False` with error |
| CapitalGainsGuard | `guards/capital_gains_guard.py:54-55` | Unknown asset/term → `verified=True` "No hard constraint" | `verified=False` with error |
| NexusGuard | `guards/nexus_guard.py:30-31` | Unknown state → `verified=True` "not in high-risk list" | `verified=False` with error |
| AddressGuard | `address_guard.py:26-27` | Unknown state → `verified=True` "Assumed Valid" | `verified=False` "manual review required" |
| Form1099Guard | `jurisdictions/us/form1099_guard.py:27-32` | Unknown payment type → `filing_required=False` | `filing_required=None` "manual determination required" |
| InputCreditGuard | `guards/indirect_tax_guard.py:102-111` | Unknown category → `verified=True` (silent) | `verified=True` + `unverified_category=True` flag |

## CRITICAL fix: TDSGuard + TaxPreFlight amplification

TDSGuard was the live exploitation path: AI agent classifies payment under unrecognized category → TDSGuard says "verified, zero deduction" → `TaxPreFlight._check_invoice_tds()` sees `verified=True, deduction="0"` → no block appended → `allowed=True` → payment executes with no withholding.

## InputCreditGuard approach

ITC under GST law is "allowed unless specifically blocked" — so `verified=True` is the correct legal default. However, unknown categories are now explicitly flagged with `unverified_category: True` in the return dict, so consumers can distinguish "known-eligible" from "default-allowed-unknown". The `audit_trace` also carries `category_match: "default_allow"`.

## Test changes

- `test_audit_trace.py::test_unknown_category_has_no_trace` — updated to assert `verified=False` instead of `verified=True`

## Test results

107 tests pass, 0 regressions. Ruff lint clean.

## Related

- Closes #16
- Partially addresses #19 (TDS amplification path V1)
- Conforms to future `TaxDiagnosticResult` contract (#39) — all fail-closed paths return `verified=False` with structured error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Tax verification checks now flag incomplete or missing configurations for manual review, improving accuracy and compliance safeguards.
  - Indirect tax eligibility tracking now includes enhanced audit trail information.
  - Filing requirement determination updated to request manual review when applicable rules are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->